### PR TITLE
feat: Infinite Scrolling

### DIFF
--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -204,6 +204,7 @@
     let isScrolling = $state(false) // Tracks active scrolling state
     let lastMeasuredIndex = $state(-1) // Index of last measured item
     let isListComplete = $state(false) // Tracks if all items have been loaded
+    let isLoadingData = $state(false) // Tracks if data is currently being loaded
 
     /**
      * Timers and Observers
@@ -358,13 +359,13 @@
 
         if (!isScrolling) {
             isScrolling = true
-            rafSchedule(() => {
+            rafSchedule(async () => {
                 scrollTop = viewportElement.scrollTop
                 isScrolling = false
 
                 // Infinite scroll handling
                 // Only invoke if onReachEnd is defined
-                if (onReachEnd && initialized && !isListComplete) {
+                if (onReachEnd && initialized && !isListComplete && !isLoadingData) {
                     const scrollHeight = viewportElement.scrollHeight
                     const clientHeight = viewportElement.clientHeight
 
@@ -373,7 +374,9 @@
                         scrollHeight - (scrollTop + clientHeight) <= endThreshold ||
                         scrollHeight <= clientHeight + endThreshold
                     ) {
-                        isListComplete = onReachEnd()
+                        isLoadingData = true
+                        isListComplete = await onReachEnd()
+                        isLoadingData = false
                     }
                 }
             })
@@ -538,7 +541,8 @@
             initialized &&
             viewportElement &&
             viewportElement.scrollHeight <= viewportElement.clientHeight + endThreshold &&
-            !isListComplete
+            !isListComplete &&
+            !isLoadingData
         ) {
             onReachEnd()
         }

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -375,18 +375,18 @@
                     const scrollHeight = viewportElement.scrollHeight
                     const clientHeight = viewportElement.clientHeight
                     const currentTime = Date.now()
-                    
+
                     // Reset call count if enough time has passed
                     if (currentTime - onReachEndLastCallTime > infiniteLoopPreventionTimeout) {
                         onReachEndCallCount = 0
                     }
-                    
+
                     // Prevent infinite loops by limiting calls
                     if (onReachEndCallCount >= infiniteLoopPreventionCallCount) {
                         console.warn(
                             'SvelteVirtualList: onReachEnd has been called too many times in a short period. ' +
-                            'This usually indicates an infinite loop. Disabling further calls. ' +
-                            'Check your onReachEnd implementation to ensure it properly loads data or returns true when complete.'
+                                'This usually indicates an infinite loop. Disabling further calls. ' +
+                                'Check your onReachEnd implementation to ensure it properly loads data or returns true when complete.'
                         )
                         isListComplete = true
                         return
@@ -415,7 +415,7 @@
                     if (shouldTrigger) {
                         onReachEndCallCount++
                         onReachEndLastCallTime = currentTime
-                        
+
                         isLoadingData = true
                         isListComplete = await onReachEnd()
                         isLoadingData = false
@@ -578,29 +578,23 @@
     })
 
     $effect(() => {
-        if (
-            onReachEnd &&
-            initialized &&
-            viewportElement &&
-            !isListComplete &&
-            !isLoadingData
-        ) {
+        if (onReachEnd && initialized && viewportElement && !isListComplete && !isLoadingData) {
             const scrollHeight = viewportElement.scrollHeight
             const clientHeight = viewportElement.clientHeight
             const currentTime = Date.now()
-            
+
             // Reset call count if enough time has passed (reset every 5 seconds)
-            $inspect(currentTime, onReachEndLastCallTime, currentTime - onReachEndLastCallTime);
+            $inspect(currentTime, onReachEndLastCallTime, currentTime - onReachEndLastCallTime)
             if (currentTime - onReachEndLastCallTime > infiniteLoopPreventionTimeout) {
                 onReachEndCallCount = 0
             }
-            
+
             // Prevent infinite loops by limiting calls
             if (onReachEndCallCount >= infiniteLoopPreventionCallCount) {
                 console.warn(
                     'SvelteVirtualList: onReachEnd has been called too many times in a short period. ' +
-                    'This usually indicates an infinite loop. Disabling further calls. ' +
-                    'Check your onReachEnd implementation to ensure it properly loads data or returns true when complete.'
+                        'This usually indicates an infinite loop. Disabling further calls. ' +
+                        'Check your onReachEnd implementation to ensure it properly loads data or returns true when complete.'
                 )
                 isListComplete = true
                 return
@@ -610,7 +604,7 @@
             if (scrollHeight <= clientHeight + endThreshold) {
                 onReachEndCallCount++
                 onReachEndLastCallTime = currentTime
-                
+
                 isLoadingData = true
                 const result = onReachEnd()
                 if (result instanceof Promise) {

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -583,8 +583,7 @@
             const clientHeight = viewportElement.clientHeight
             const currentTime = Date.now()
 
-            // Reset call count if enough time has passed (reset every 5 seconds)
-            $inspect(currentTime, onReachEndLastCallTime, currentTime - onReachEndLastCallTime)
+            // Reset call count if enough time has passed (reset after infiniteLoopPreventionTimeout)
             if (currentTime - onReachEndLastCallTime > infiniteLoopPreventionTimeout) {
                 onReachEndCallCount = 0
             }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -77,6 +77,18 @@ export type SvelteVirtualListProps = {
      * @default 32
      */
     endThreshold?: number
+    /**
+     * Maximum number of times the onReachEnd callback can be called in a short period to prevent excessive calls.
+     * @default 3
+     */
+    infiniteLoopPreventionCallCount?: number
+    /**
+     * Amount of time in milliseconds before the loop prevention counter resets.
+     * If onReachEnd is called more than infiniteLoopPreventionCallCount times within this period this period,
+     * the callback will be disabled to prevent rapid repeated calls.
+     * @default 5
+     */
+    infiniteLoopPreventionTimeout?: number
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -66,29 +66,37 @@ export type SvelteVirtualListProps = {
      */
     viewportClass?: string
     /**
+     * When true, enables infinite scrolling behavior, if a callback is provided.
+     * If false, the list will not trigger the infiniteScrollCallback.
+     * This is useful for disabling infinite scroll while loading data externally.
+     * @default true
+     */
+    infiniteScrollEnabled?: boolean
+    /**
      * Callback function triggered when the user reaches the end of the list.
      * May be used to load more items dynamically (e.g., for infinite scrolling).
+     * If left undefined, infinite scrolling will not be enabled.
      * @returns {Promise<boolean> | boolean} - Returns true if more items are available to load, false otherwise.
      */
-    onReachEnd?: () => Promise<boolean> | boolean
+    infiniteScrollCallback?: () => Promise<boolean> | boolean
     /**
      * Threshold in pixels to trigger the onReachEnd callback.
      * When the user scrolls within this distance from the end of the list, the callback is invoked.
      * @default 32
      */
-    endThreshold?: number
+    infiniteScrollThreshold?: number
     /**
-     * Maximum number of times the onReachEnd callback can be called in a short period to prevent excessive calls.
+     * Maximum number of times the infiniteScrollCallback can be called in a short period to prevent excessive calls.
      * @default 3
      */
-    infiniteLoopPreventionCallCount?: number
+    infiniteScrollLoopPreventionCallCount?: number
     /**
      * Amount of time in milliseconds before the loop prevention counter resets.
      * If onReachEnd is called more than infiniteLoopPreventionCallCount times within this period this period,
      * the callback will be disabled to prevent rapid repeated calls.
      * @default 5
      */
-    infiniteLoopPreventionTimeout?: number
+    infiniteScrollLoopPreventionTimeout?: number
 }
 
 /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,6 +65,18 @@ export type SvelteVirtualListProps = {
      * CSS class to apply to the scrollable viewport element.
      */
     viewportClass?: string
+    /**
+     * Callback function triggered when the user reaches the end of the list.
+     * May be used to load more items dynamically (e.g., for infinite scrolling).
+     * @returns {Promise<boolean> | boolean} - Returns true if more items are available to load, false otherwise.
+     */
+    onReachEnd?: () => Promise<boolean> | boolean
+    /**
+     * Threshold in pixels to trigger the onReachEnd callback.
+     * When the user scrolls within this distance from the end of the list, the callback is invoked.
+     * @default 32
+     */
+    endThreshold?: number
 }
 
 /**

--- a/src/routes/tests/infinite-scroll/+page.svelte
+++ b/src/routes/tests/infinite-scroll/+page.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
     import SvelteVirtualList from '$lib/index.js'
 
-    const items = $state(Array.from({ length: 100 }, (_, i) => ({
-        id: i,
-        text: `Item ${i}`
-    })))
+    const items = $state(
+        Array.from({ length: 100 }, (_, i) => ({
+            id: i,
+            text: `Item ${i}`
+        }))
+    )
 
     function loadMoreItems() {
         // Simulate loading more items
-        const currentLength = items.length;
+        const currentLength = items.length
         const newItems = Array.from({ length: 100 }, (_, i) => ({
             id: currentLength + i,
             text: `Item ${currentLength + i}`
-        }));
-        items.push(...newItems);
-        return false;
+        }))
+        items.push(...newItems)
+        return false
     }
 </script>
 

--- a/src/routes/tests/infinite-scroll/+page.svelte
+++ b/src/routes/tests/infinite-scroll/+page.svelte
@@ -14,6 +14,7 @@
             text: `Item ${currentLength + i}`
         }));
         items.push(...newItems);
+        return false;
     }
 </script>
 

--- a/src/routes/tests/infinite-scroll/+page.svelte
+++ b/src/routes/tests/infinite-scroll/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    import SvelteVirtualList from '$lib/index.js'
+
+    const items = $state(Array.from({ length: 100 }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    })))
+
+    function loadMoreItems() {
+        // Simulate loading more items
+        const currentLength = items.length;
+        const newItems = Array.from({ length: 100 }, (_, i) => ({
+            id: currentLength + i,
+            text: `Item ${currentLength + i}`
+        }));
+        items.push(...newItems);
+    }
+</script>
+
+<div class="test-container" style="height: 500px;">
+    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems}>
+        {#snippet renderItem(item)}
+            <div class="test-item" data-testid="list-item-{item.id}">
+                {item.text}
+            </div>
+        {/snippet}
+    </SvelteVirtualList>
+</div>

--- a/src/routes/tests/infinite-scroll/+page.svelte
+++ b/src/routes/tests/infinite-scroll/+page.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <div class="test-container" style="height: 500px;">
-    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems}>
+    <SvelteVirtualList {items} testId="basic-list" infiniteScrollCallback={loadMoreItems}>
         {#snippet renderItem(item)}
             <div class="test-item" data-testid="list-item-{item.id}">
                 {item.text}

--- a/src/routes/tests/infinite-scroll/async/+page.svelte
+++ b/src/routes/tests/infinite-scroll/async/+page.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+    import SvelteVirtualList from '$lib/index.js'
+
+    const items = $state(Array.from({ length: 100 }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    })))
+
+    function loadMoreItems(): Promise<boolean> {
+        // Simulate loading more items after a delay
+        console.log('Loading more items...');
+        return new Promise((resolve) => {
+            setTimeout(() => {
+                const currentLength = items.length;
+                const newItems = Array.from({ length: 100 }, (_, i) => ({
+                    id: currentLength + i,
+                    text: `Item ${currentLength + i}`
+                }));
+                items.push(...newItems);
+                resolve(false); // Indicate that more items can be loaded
+            }, 1000); // Simulate a 1 second delay for loading
+        });
+    }
+</script>
+
+<div class="test-container" style="height: 500px;">
+    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems}>
+        {#snippet renderItem(item)}
+            <div class="test-item" data-testid="list-item-{item.id}">
+                {item.text}
+            </div>
+        {/snippet}
+    </SvelteVirtualList>
+</div>

--- a/src/routes/tests/infinite-scroll/async/+page.svelte
+++ b/src/routes/tests/infinite-scroll/async/+page.svelte
@@ -1,25 +1,27 @@
 <script lang="ts">
     import SvelteVirtualList from '$lib/index.js'
 
-    const items = $state(Array.from({ length: 100 }, (_, i) => ({
-        id: i,
-        text: `Item ${i}`
-    })))
+    const items = $state(
+        Array.from({ length: 100 }, (_, i) => ({
+            id: i,
+            text: `Item ${i}`
+        }))
+    )
 
     function loadMoreItems(): Promise<boolean> {
         // Simulate loading more items after a delay
-        console.log('Loading more items...');
+        console.log('Loading more items...')
         return new Promise((resolve) => {
             setTimeout(() => {
-                const currentLength = items.length;
+                const currentLength = items.length
                 const newItems = Array.from({ length: 100 }, (_, i) => ({
                     id: currentLength + i,
                     text: `Item ${currentLength + i}`
-                }));
-                items.push(...newItems);
-                resolve(false); // Indicate that more items can be loaded
-            }, 1000); // Simulate a 1 second delay for loading
-        });
+                }))
+                items.push(...newItems)
+                resolve(false) // Indicate that more items can be loaded
+            }, 1000) // Simulate a 1 second delay for loading
+        })
     }
 </script>
 

--- a/src/routes/tests/infinite-scroll/async/+page.svelte
+++ b/src/routes/tests/infinite-scroll/async/+page.svelte
@@ -26,7 +26,7 @@
 </script>
 
 <div class="test-container" style="height: 500px;">
-    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems}>
+    <SvelteVirtualList {items} testId="basic-list" infiniteScrollCallback={loadMoreItems}>
         {#snippet renderItem(item)}
             <div class="test-item" data-testid="list-item-{item.id}">
                 {item.text}

--- a/src/routes/tests/infinite-scroll/bottom-to-top/+page.svelte
+++ b/src/routes/tests/infinite-scroll/bottom-to-top/+page.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
     import SvelteVirtualList from '$lib/index.js'
 
-    const items = $state(Array.from({ length: 100 }, (_, i) => ({
-        id: i,
-        text: `Item ${i}`
-    })))
+    const items = $state(
+        Array.from({ length: 100 }, (_, i) => ({
+            id: i,
+            text: `Item ${i}`
+        }))
+    )
 
     function loadMoreItems() {
         // Simulate loading more items
-        const currentLength = items.length;
+        const currentLength = items.length
         const newItems = Array.from({ length: 100 }, (_, i) => ({
             id: currentLength + i,
             text: `Item ${currentLength + i}`
-        }));
-        items.push(...newItems);
-        return false;
+        }))
+        items.push(...newItems)
+        return false
     }
 </script>
 

--- a/src/routes/tests/infinite-scroll/bottom-to-top/+page.svelte
+++ b/src/routes/tests/infinite-scroll/bottom-to-top/+page.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <div class="test-container" style="height: 500px;">
-    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems} mode="bottomToTop">
+    <SvelteVirtualList {items} testId="basic-list" infiniteScrollCallback={loadMoreItems} mode="bottomToTop">
         {#snippet renderItem(item)}
             <div class="test-item" data-testid="list-item-{item.id}">
                 {item.text}

--- a/src/routes/tests/infinite-scroll/bottom-to-top/+page.svelte
+++ b/src/routes/tests/infinite-scroll/bottom-to-top/+page.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+    import SvelteVirtualList from '$lib/index.js'
+
+    const items = $state(Array.from({ length: 100 }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    })))
+
+    function loadMoreItems() {
+        // Simulate loading more items
+        const currentLength = items.length;
+        const newItems = Array.from({ length: 100 }, (_, i) => ({
+            id: currentLength + i,
+            text: `Item ${currentLength + i}`
+        }));
+        items.push(...newItems);
+        return false;
+    }
+</script>
+
+<div class="test-container" style="height: 500px;">
+    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems} mode="bottomToTop">
+        {#snippet renderItem(item)}
+            <div class="test-item" data-testid="list-item-{item.id}">
+                {item.text}
+            </div>
+        {/snippet}
+    </SvelteVirtualList>
+</div>

--- a/src/routes/tests/infinite-scroll/disabled-externally/+page.svelte
+++ b/src/routes/tests/infinite-scroll/disabled-externally/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import SvelteVirtualList from '$lib/index.js'
 
+    let infiniteScrollEnabled = $state(true)
+
     const items = $state(
         Array.from({ length: 100 }, (_, i) => ({
             id: i,
@@ -8,7 +10,7 @@
         }))
     )
 
-    function loadMoreItems(): boolean {
+    function loadMoreItems() {
         // Simulate loading more items
         const currentLength = items.length
         const newItems = Array.from({ length: 100 }, (_, i) => ({
@@ -16,16 +18,13 @@
             text: `Item ${currentLength + i}`
         }))
         items.push(...newItems)
-        if (items.length >= 1000) {
-            // Stop loading more items after reaching a limit
-            return true // Indicate that the list is complete
-        }
-        return false // Indicate that more items can be loaded
+        return false
     }
 </script>
 
+<input type="checkbox" bind:checked={infiniteScrollEnabled} /> Infinite Scroll Enabled
 <div class="test-container" style="height: 500px;">
-    <SvelteVirtualList {items} testId="basic-list" infiniteScrollCallback={loadMoreItems}>
+    <SvelteVirtualList {items} testId="basic-list" infiniteScrollCallback={loadMoreItems} {infiniteScrollEnabled}>
         {#snippet renderItem(item)}
             <div class="test-item" data-testid="list-item-{item.id}">
                 {item.text}

--- a/src/routes/tests/infinite-scroll/end-threshold/+page.svelte
+++ b/src/routes/tests/infinite-scroll/end-threshold/+page.svelte
@@ -1,20 +1,22 @@
 <script lang="ts">
     import SvelteVirtualList from '$lib/index.js'
 
-    const items = $state(Array.from({ length: 100 }, (_, i) => ({
-        id: i,
-        text: `Item ${i}`
-    })))
+    const items = $state(
+        Array.from({ length: 100 }, (_, i) => ({
+            id: i,
+            text: `Item ${i}`
+        }))
+    )
 
     function loadMoreItems() {
         // Simulate loading more items
-        const currentLength = items.length;
+        const currentLength = items.length
         const newItems = Array.from({ length: 100 }, (_, i) => ({
             id: currentLength + i,
             text: `Item ${currentLength + i}`
-        }));
-        items.push(...newItems);
-        return false;
+        }))
+        items.push(...newItems)
+        return false
     }
 </script>
 

--- a/src/routes/tests/infinite-scroll/end-threshold/+page.svelte
+++ b/src/routes/tests/infinite-scroll/end-threshold/+page.svelte
@@ -21,7 +21,7 @@
 </script>
 
 <div class="test-container" style="height: 500px;">
-    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems} endThreshold={200}>
+    <SvelteVirtualList {items} testId="basic-list" infiniteScrollCallback={loadMoreItems} infiniteScrollThreshold={200}>
         {#snippet renderItem(item)}
             <div class="test-item" data-testid="list-item-{item.id}">
                 {item.text}

--- a/src/routes/tests/infinite-scroll/end-threshold/+page.svelte
+++ b/src/routes/tests/infinite-scroll/end-threshold/+page.svelte
@@ -14,6 +14,7 @@
             text: `Item ${currentLength + i}`
         }));
         items.push(...newItems);
+        return false;
     }
 </script>
 

--- a/src/routes/tests/infinite-scroll/end-threshold/+page.svelte
+++ b/src/routes/tests/infinite-scroll/end-threshold/+page.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    import SvelteVirtualList from '$lib/index.js'
+
+    const items = $state(Array.from({ length: 100 }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    })))
+
+    function loadMoreItems() {
+        // Simulate loading more items
+        const currentLength = items.length;
+        const newItems = Array.from({ length: 100 }, (_, i) => ({
+            id: currentLength + i,
+            text: `Item ${currentLength + i}`
+        }));
+        items.push(...newItems);
+    }
+</script>
+
+<div class="test-container" style="height: 500px;">
+    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems} endThreshold={200}>
+        {#snippet renderItem(item)}
+            <div class="test-item" data-testid="list-item-{item.id}">
+                {item.text}
+            </div>
+        {/snippet}
+    </SvelteVirtualList>
+</div>

--- a/src/routes/tests/infinite-scroll/limits/+page.svelte
+++ b/src/routes/tests/infinite-scroll/limits/+page.svelte
@@ -1,24 +1,26 @@
 <script lang="ts">
     import SvelteVirtualList from '$lib/index.js'
 
-    const items = $state(Array.from({ length: 100 }, (_, i) => ({
-        id: i,
-        text: `Item ${i}`
-    })))
+    const items = $state(
+        Array.from({ length: 100 }, (_, i) => ({
+            id: i,
+            text: `Item ${i}`
+        }))
+    )
 
     function loadMoreItems(): boolean {
         // Simulate loading more items
-        const currentLength = items.length;
+        const currentLength = items.length
         const newItems = Array.from({ length: 100 }, (_, i) => ({
             id: currentLength + i,
             text: `Item ${currentLength + i}`
-        }));
-        items.push(...newItems);
+        }))
+        items.push(...newItems)
         if (items.length >= 1000) {
             // Stop loading more items after reaching a limit
-            return true; // Indicate that the list is complete
+            return true // Indicate that the list is complete
         }
-        return false; // Indicate that more items can be loaded
+        return false // Indicate that more items can be loaded
     }
 </script>
 

--- a/src/routes/tests/infinite-scroll/limits/+page.svelte
+++ b/src/routes/tests/infinite-scroll/limits/+page.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+    import SvelteVirtualList from '$lib/index.js'
+
+    const items = $state(Array.from({ length: 100 }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    })))
+
+    function loadMoreItems(): boolean {
+        // Simulate loading more items
+        const currentLength = items.length;
+        const newItems = Array.from({ length: 100 }, (_, i) => ({
+            id: currentLength + i,
+            text: `Item ${currentLength + i}`
+        }));
+        items.push(...newItems);
+        if (items.length >= 1000) {
+            // Stop loading more items after reaching a limit
+            return true; // Indicate that the list is complete
+        }
+        return false; // Indicate that more items can be loaded
+    }
+</script>
+
+<div class="test-container" style="height: 500px;">
+    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems}>
+        {#snippet renderItem(item)}
+            <div class="test-item" data-testid="list-item-{item.id}">
+                {item.text}
+            </div>
+        {/snippet}
+    </SvelteVirtualList>
+</div>

--- a/src/routes/tests/infinite-scroll/loop-prevention/+page.svelte
+++ b/src/routes/tests/infinite-scroll/loop-prevention/+page.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
     import SvelteVirtualList from '$lib/index.js'
 
-    const items = $state(Array.from({ length: 10 }, (_, i) => ({
-        id: i,
-        text: `Item ${i}`
-    })))
+    const items = $state(
+        Array.from({ length: 10 }, (_, i) => ({
+            id: i,
+            text: `Item ${i}`
+        }))
+    )
 
     function loadMoreItems() {
-        return false;
+        return false
     }
 </script>
 

--- a/src/routes/tests/infinite-scroll/loop-prevention/+page.svelte
+++ b/src/routes/tests/infinite-scroll/loop-prevention/+page.svelte
@@ -14,7 +14,7 @@
 </script>
 
 <div class="test-container" style="height: 500px;">
-    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems}>
+    <SvelteVirtualList {items} testId="basic-list" infiniteScrollCallback={loadMoreItems}>
         {#snippet renderItem(item)}
             <div class="test-item" data-testid="list-item-{item.id}">
                 {item.text}

--- a/src/routes/tests/infinite-scroll/loop-prevention/+page.svelte
+++ b/src/routes/tests/infinite-scroll/loop-prevention/+page.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+    import SvelteVirtualList from '$lib/index.js'
+
+    const items = $state(Array.from({ length: 10 }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    })))
+
+    function loadMoreItems() {
+        return false;
+    }
+</script>
+
+<div class="test-container" style="height: 500px;">
+    <SvelteVirtualList {items} testId="basic-list" onReachEnd={loadMoreItems}>
+        {#snippet renderItem(item)}
+            <div class="test-item" data-testid="list-item-{item.id}">
+                {item.text}
+            </div>
+        {/snippet}
+    </SvelteVirtualList>
+</div>


### PR DESCRIPTION
[Tracking issue](https://github.com/humanspeak/svelte-virtual-list/issues/207)

Currently implemented:

* An option to turn infinite scroll on / off (defaults to off)
* Triggering a callback function when you scroll past a definable threshold
* A way to disable infinite scroll if the callback function returns that the list is "complete"
* A system to detect infinite loops (if you scroll to the bottom and load data that doesn't return anything) and to cut off infinite scrolling if this happens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added infinite scrolling support to the virtual list component, including customizable scroll threshold, callback, and loop prevention options.
  * Infinite scrolling now supports both top-to-bottom and bottom-to-top modes.
  * Users can enable or disable infinite scroll dynamically and set limits on how many times more items are loaded.

* **Tests**
  * Introduced several new test pages demonstrating infinite scroll functionality, including async loading, scroll threshold configuration, direction modes, external enabling/disabling, item limits, and loop prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->