### PR TITLE
feat: Use generic type argument for items

### DIFF
--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -60,7 +60,7 @@
     MIT License © Humanspeak, Inc.
 -->
 
-<script lang="ts" generics="TItem">
+<script lang="ts" generics="TItem = never">
     /**
      * SvelteVirtualList Implementation Journey
      *

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -60,7 +60,7 @@
     MIT License © Humanspeak, Inc.
 -->
 
-<script lang="ts" generics="TItem = never">
+<script lang="ts" generics="TItem = any">
     /**
      * SvelteVirtualList Implementation Journey
      *

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -727,7 +727,7 @@
             >
                 {#each mode === 'bottomToTop' ? items
                           .slice(visibleItems().start, visibleItems().end)
-                          .reverse() : items.slice(visibleItems().start, visibleItems().end) as currentItem, i ((currentItem as { id?: any })?.id ?? i)}
+                          .reverse() : items.slice(visibleItems().start, visibleItems().end) as currentItem, i ((currentItem as { id?: string | number })?.id ?? i)}
                     <!-- Only debug when visible range or average height changes -->
                     {#if debug && i === 0 && shouldShowDebugInfo(prevVisibleRange, visibleItems(), prevHeight, calculatedItemHeight)}
                         {@const debugInfo = createDebugInfo(

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -60,7 +60,7 @@
     MIT License © Humanspeak, Inc.
 -->
 
-<script lang="ts">
+<script lang="ts" generics="TItem">
     /**
      * SvelteVirtualList Implementation Journey
      *
@@ -163,7 +163,7 @@
 
     /**
      * Core configuration props with default values
-     * @type {SvelteVirtualListProps}
+     * @type {SvelteVirtualListProps<TItem>}
      */
     const {
         items = [], // Array of items to be rendered in the virtual list
@@ -178,7 +178,7 @@
         mode = 'topToBottom', // Scroll direction mode
         bufferSize = 20, // Number of items to render outside visible area
         testId // Base test ID for component elements (undefined = no data-testid attributes)
-    }: SvelteVirtualListProps = $props()
+    }: SvelteVirtualListProps<TItem> = $props()
 
     /**
      * DOM References and Core State
@@ -727,7 +727,7 @@
             >
                 {#each mode === 'bottomToTop' ? items
                           .slice(visibleItems().start, visibleItems().end)
-                          .reverse() : items.slice(visibleItems().start, visibleItems().end) as currentItem, i (currentItem?.id ?? i)}
+                          .reverse() : items.slice(visibleItems().start, visibleItems().end) as currentItem, i ((currentItem as { id?: any })?.id ?? i)}
                     <!-- Only debug when visible range or average height changes -->
                     {#if debug && i === 0 && shouldShowDebugInfo(prevVisibleRange, visibleItems(), prevHeight, calculatedItemHeight)}
                         {@const debugInfo = createDebugInfo(

--- a/src/lib/SvelteVirtualList.test.ts
+++ b/src/lib/SvelteVirtualList.test.ts
@@ -23,7 +23,7 @@ describe('testing initialization', () => {
             props: {
                 testId: 'test-id',
                 items: []
-            } as unknown as SvelteVirtualListProps
+            } as unknown as SvelteVirtualListProps<any>
         })
 
         // Wait for all timers and effects to settle

--- a/src/lib/index.test.ts
+++ b/src/lib/index.test.ts
@@ -30,7 +30,7 @@ describe('index.ts exports', () => {
 
         // Use a mock Snippet for renderItem
         const mockSnippet: Snippet = (() => {}) as unknown as Snippet
-        const props: SvelteVirtualListProps = {
+        const props: SvelteVirtualListProps<any> = {
             items: [],
             renderItem: mockSnippet
         }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export type SvelteVirtualListMode = 'topToBottom' | 'bottomToTop'
  *
  * @typedef {Object} SvelteVirtualListProps
  */
-export type SvelteVirtualListProps<TItem> = {
+export type SvelteVirtualListProps<TItem = never> = {
     /**
      * Number of items to render outside the visible viewport for smooth scrolling.
      * @default 20

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export type SvelteVirtualListMode = 'topToBottom' | 'bottomToTop'
  *
  * @typedef {Object} SvelteVirtualListProps
  */
-export type SvelteVirtualListProps = {
+export type SvelteVirtualListProps<TItem> = {
     /**
      * Number of items to render outside the visible viewport for smooth scrolling.
      * @default 20
@@ -43,7 +43,7 @@ export type SvelteVirtualListProps = {
     /**
      * The complete array of items to be virtualized.
      */
-    items: any[] // eslint-disable-line @typescript-eslint/no-explicit-any
+    items: TItem[]
     /**
      * CSS class to apply to individual item containers.
      */
@@ -56,7 +56,7 @@ export type SvelteVirtualListProps = {
     /**
      * Svelte snippet function that defines how each item should be rendered. Receives the item and its index as arguments.
      */
-    renderItem: Snippet<[item: any, index: number]> // eslint-disable-line @typescript-eslint/no-explicit-any
+    renderItem: Snippet<[item: TItem, index: number]>
     /**
      * Base test ID for component elements to facilitate testing.
      */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -12,7 +12,7 @@ export type SvelteVirtualListMode = 'topToBottom' | 'bottomToTop'
  *
  * @typedef {Object} SvelteVirtualListProps
  */
-export type SvelteVirtualListProps<TItem = never> = {
+export type SvelteVirtualListProps<TItem = any> = { // eslint-disable-line @typescript-eslint/no-explicit-any
     /**
      * Number of items to render outside the visible viewport for smooth scrolling.
      * @default 20

--- a/src/routes/tests/scroll/bottomToTop/+page.svelte
+++ b/src/routes/tests/scroll/bottomToTop/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import SvelteVirtualList, { type SvelteVirtualListScrollAlign } from '$lib/index.js'
 
-    let virtualList: SvelteVirtualList
+    let virtualList: SvelteVirtualList<any>
 
     type Item = {
         id: number

--- a/src/routes/tests/scroll/topToBottom/+page.svelte
+++ b/src/routes/tests/scroll/topToBottom/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import SvelteVirtualList, { type SvelteVirtualListScrollAlign } from '$lib/index.js'
 
-    let virtualList: SvelteVirtualList
+    let virtualList: SvelteVirtualList<any>
 
     type Item = {
         id: number


### PR DESCRIPTION
This pull request replaces `any` inside the virtual-list component and type definitions with a generic TItem type.
This has the advantage of better type safety and that the item type is properly forwarded when using the `renderItem`.

Before:
```svelte
    <SvelteVirtualList items={messages} mode="bottomToTop" debug>
        {#snippet renderItem(message: Message)} <!-- Type has to be specified since it would otherwise be any -->
            <div class="message-container">
                <p>{message.text}</p>
            </div>
        {/snippet}
    </SvelteVirtualList>
```

After:
```svelte
    <SvelteVirtualList items={messages} mode="bottomToTop" debug>
        {#snippet renderItem(message)} <!-- Type is known here since it's forwarded as our generic TItem arg -->
            <div class="message-container">
                <p>{message.text}</p>
            </div>
        {/snippet}
    </SvelteVirtualList>
```

Currently `TItem` will default to `any` if it's not specified or cannot be inferred from usage. Though ideally it should be set to `unknown` but using `unknown` might make it a breaking change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Enhanced type flexibility and safety for the virtual list component by introducing generic typing.
  * Updated type annotations in tests and example pages to align with the new generic typing approach.

* **Tests**
  * Modified test files to explicitly specify the generic type parameter for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->