### PR TITLE
chore: move derived functions to $derived.by

### DIFF
--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -251,11 +251,11 @@
 
     const captureAnchor = () => {
         if (!heightManager.viewportElement) return
-        const vr = visibleItems()
+        const vr = visibleItems
         const anchorIndex = Math.max(0, vr.start)
         const cache = heightManager.getHeightCache()
         const est = heightManager.averageHeight
-        const maxScrollTop = Math.max(0, totalHeight() - (height || 0))
+        const maxScrollTop = Math.max(0, totalHeight - (height || 0))
         // Offset from start to anchored item
         const blockSums = buildBlockSums(cache, est, items.length)
         const offsetToIndex = getScrollOffsetForIndex(cache, est, anchorIndex, blockSums)
@@ -290,7 +290,7 @@
             Math.max(0, lastAnchorIndex),
             blockSums
         )
-        const maxScrollTop = clampValue(totalHeight() - (height || 0), 0, Infinity)
+        const maxScrollTop = clampValue(totalHeight - (height || 0), 0, Infinity)
         let targetTop: number
         if (mode === 'bottomToTop') {
             const distanceFromStart = clampValue(offsetToIndex + lastAnchorOffset, 0, Infinity)
@@ -402,8 +402,8 @@
     // Dynamic update coordination to avoid UA scroll anchoring interference
     let suppressBottomAnchoringUntilMs = $state(0)
 
-    const displayItems = $derived(() => {
-        const visibleRange = visibleItems()
+    const displayItems = $derived.by(() => {
+        const visibleRange = visibleItems
         const slice =
             mode === 'bottomToTop'
                 ? items.slice(visibleRange.start, visibleRange.end).reverse()
@@ -442,7 +442,7 @@
         if (isScrolling) {
             // Accumulate net change above viewport and defer application
             let pending = 0
-            const currentVisibleRange = visibleItems()
+            const currentVisibleRange = visibleItems
             for (const change of heightChanges) {
                 if (change.index < currentVisibleRange.start) pending += change.delta
             }
@@ -518,7 +518,7 @@
             lastCorrectionTimestampByViewport.set(viewportEl, now)
 
             // Step 1: Scroll to approximate position to ensure Item 0 gets rendered in virtual viewport
-            const approximateScrollTop = Math.max(0, totalHeight() - height)
+            const approximateScrollTop = Math.max(0, totalHeight - height)
             log('[SVL] b2t-correction-approx', { approximateScrollTop })
             syncScrollTop(approximateScrollTop)
 
@@ -555,11 +555,11 @@
         }
 
         const currentScrollTop = heightManager.viewport.scrollTop
-        const maxScrollTop = Math.max(0, totalHeight() - height)
+        const maxScrollTop = Math.max(0, totalHeight - height)
 
         // Calculate total height change impact above current visible area
         let heightChangeAboveViewport = 0
-        const currentVisibleRange = visibleItems()
+        const currentVisibleRange = visibleItems
 
         for (const change of heightChanges) {
             // Only consider items that are above the current visible range
@@ -623,7 +623,7 @@
         // Skip loading during bottomToTop initialization (init path renders all items artificially)
         if (mode === 'bottomToTop' && !bottomToTopScrollComplete) return
 
-        const range = visibleItems()
+        const range = visibleItems
         const atLoadingEdge = range.end >= items.length - loadMoreThreshold
         const insufficientItems = items.length < loadMoreThreshold && heightManager.initialized
 
@@ -748,9 +748,9 @@
      * This getter is reactive and updates whenever heightManager's internal state changes.
      * Used by: atBottom calculation, scroll corrections, maxScrollTop calculations
      */
-    const totalHeight = $derived(() => heightManager.totalHeight)
+    const totalHeight = $derived.by(() => heightManager.totalHeight)
 
-    const atBottom = $derived(heightManager.scrollTop >= totalHeight() - height - 1)
+    const atBottom = $derived(heightManager.scrollTop >= totalHeight - height - 1)
     let wasAtBottomBeforeHeightChange = false
     let lastVisibleRange: SvelteVirtualListPreviousVisibleRange | null = null
 
@@ -780,7 +780,7 @@
             mode === 'bottomToTop' &&
             heightManager.viewportElement
         ) {
-            const targetScrollTop = Math.max(0, totalHeight() - height)
+            const targetScrollTop = Math.max(0, totalHeight - height)
             const currentScrollTop = heightManager.viewport.scrollTop
             const scrollDifference = Math.abs(currentScrollTop - targetScrollTop)
 
@@ -790,7 +790,7 @@
             // 3. We're significantly off target
             // 4. We're not at the bottom (where height changes should be handled more carefully)
             const heightChanged = Math.abs(heightManager.averageHeight - lastCalculatedHeight) > 1
-            const maxScrollTop = Math.max(0, totalHeight() - height)
+            const maxScrollTop = Math.max(0, totalHeight - height)
 
             // In bottomToTop mode, we're "at bottom" when scroll is at max position
             const isAtBottom =
@@ -838,7 +838,7 @@
                 const currentScrollTop = heightManager.viewport.scrollTop
                 const currentCalculatedItemHeight = heightManager.averageHeight
                 const currentHeight = height
-                const currentTotalHeight = totalHeight()
+                const currentTotalHeight = totalHeight
                 const prevTotalHeight =
                     lastTotalHeightObserved ||
                     currentTotalHeight - itemsAdded * currentCalculatedItemHeight
@@ -884,7 +884,7 @@
                     // Reconcile on next frame in case measured heights adjust totals
                     requestAnimationFrame(() => {
                         const beforeReconcileScrollTop = heightManager.viewport.scrollTop
-                        const reconciledNextMax = clampValue(totalHeight() - height, 0, Infinity)
+                        const reconciledNextMax = clampValue(totalHeight - height, 0, Infinity)
                         const reconciledDeltaMaxChange = reconciledNextMax - nextMaxScrollTop
                         // Desired position is to maintain distance-from-end; equivalently keep (max - scrollTop) constant.
                         const desiredScrollTop = clampValue(
@@ -927,7 +927,7 @@
 
         lastItemsLength = currentItemsLength
         // Update last observed total height at the end of the effect
-        lastTotalHeightObserved = totalHeight()
+        lastTotalHeightObserved = totalHeight
     })
 
     // Update container height continuously to reflect layout changes that
@@ -969,7 +969,7 @@
      *
      * @returns {SvelteVirtualListPreviousVisibleRange} Object containing start and end indices of visible items
      */
-    const visibleItems = $derived((): SvelteVirtualListPreviousVisibleRange => {
+    const visibleItems = $derived.by((): SvelteVirtualListPreviousVisibleRange => {
         if (!items.length) return { start: 0, end: 0 } as SvelteVirtualListPreviousVisibleRange
         const viewportHeight = height || 0
 
@@ -1014,7 +1014,7 @@
             atBottom,
             wasAtBottomBeforeHeightChange,
             lastVisibleRange,
-            totalHeight(),
+            totalHeight,
             heightManager.getHeightCache()
         )
 
@@ -1026,15 +1026,15 @@
      * Uses the maximum of container height and total content height to ensure
      * proper scrolling behavior.
      */
-    const contentHeight = $derived(() => Math.max(height, totalHeight()))
+    const contentHeight = $derived(Math.max(height, totalHeight))
 
     /**
      * Computed transform Y value for positioning the visible items.
      * Extracted from inline IIFE for better performance and readability.
      */
-    const transformY = $derived(() => {
+    const transformY = $derived.by(() => {
         const viewportHeight = height || measuredFallbackHeight || 0
-        const visibleRange = visibleItems()
+        const visibleRange = visibleItems
 
         // Avoid synchronous DOM reads here; fall back once if height is 0
         const effectiveHeight = viewportHeight === 0 ? 400 : viewportHeight
@@ -1048,7 +1048,7 @@
                 visibleRange.start,
                 heightManager.averageHeight,
                 effectiveHeight,
-                totalHeight(),
+                totalHeight,
                 heightManager.getHeightCache(),
                 measuredFallbackHeight
             )
@@ -1117,12 +1117,12 @@
                 captureAnchor()
             }
             if (INTERNAL_DEBUG) {
-                const vr = visibleItems()
+                const vr = visibleItems
                 log('[SVL] scroll', {
                     mode,
                     scrollTop: heightManager.scrollTop,
                     height,
-                    totalHeight: totalHeight(),
+                    totalHeight: totalHeight,
                     averageItemHeight: heightManager.averageHeight,
                     visibleRange: vr
                 })
@@ -1258,7 +1258,7 @@
             rafSchedule(() => {
                 log('item-resize-observer', { entries: entries.length })
                 let shouldRecalculate = false
-                void visibleItems() // Cache once to avoid reactive loops
+                void visibleItems // Cache once to avoid reactive loops
 
                 for (const entry of entries) {
                     const element = entry.target as HTMLElement
@@ -1342,7 +1342,7 @@
     // Add the effect in the script section
     $effect(() => {
         if (INTERNAL_DEBUG) {
-            prevVisibleRange = visibleItems()
+            prevVisibleRange = visibleItems
             prevHeight = heightManager.averageHeight
         }
     })
@@ -1445,7 +1445,7 @@
             }
         }
 
-        const { start: firstVisibleIndex, end: lastVisibleIndex } = visibleItems()
+        const { start: firstVisibleIndex, end: lastVisibleIndex } = visibleItems
 
         // Use extracted scroll calculation utility
         const scrollTarget = calculateScrollTarget({
@@ -1590,26 +1590,26 @@
             id="virtual-list-content"
             {...testId ? { 'data-testid': `${testId}-content` } : {}}
             class={contentClass ?? 'virtual-list-content'}
-            style:height="{contentHeight()}px"
+            style:height="{contentHeight}px"
         >
             <!-- Items container is translated to show correct items -->
             <div
                 id="virtual-list-items"
                 {...testId ? { 'data-testid': `${testId}-items` } : {}}
                 class={itemsClass ?? 'virtual-list-items'}
-                style:transform="translateY({transformY()}px)"
+                style:transform="translateY({transformY}px)"
             >
-                {#each displayItems() as currentItemWithIndex, i (currentItemWithIndex.originalIndex)}
+                {#each displayItems as currentItemWithIndex, i (currentItemWithIndex.originalIndex)}
                     <!-- Only debug when visible range or average height changes -->
-                    {#if debug && i === 0 && shouldShowDebugInfo(prevVisibleRange, visibleItems(), prevHeight, heightManager.averageHeight)}
+                    {#if debug && i === 0 && shouldShowDebugInfo(prevVisibleRange, visibleItems, prevHeight, heightManager.averageHeight)}
                         {@const debugInfo = createDebugInfo(
-                            visibleItems(),
+                            visibleItems,
                             items.length,
                             Object.keys(heightManager.getHeightCache()).length,
                             heightManager.averageHeight,
                             heightManager.scrollTop,
                             height || 0,
-                            totalHeight()
+                            totalHeight
                         )}
                         {debugFunction
                             ? debugFunction(debugInfo)

--- a/src/lib/utils/heightCalculation.test.ts
+++ b/src/lib/utils/heightCalculation.test.ts
@@ -20,7 +20,7 @@ describe('calculateAverageHeightDebounced', () => {
         const result = calculateAverageHeightDebounced(
             false,
             null,
-            () => ({ start: 0, end: 10 }),
+            { start: 0, end: 10 },
             [],
             {},
             -1,
@@ -51,7 +51,7 @@ describe('calculateAverageHeightDebounced', () => {
         const timeoutId = calculateAverageHeightDebounced(
             false,
             null,
-            () => ({ start: 0, end: 10 }),
+            { start: 0, end: 10 },
             mockElements,
             {},
             -1,
@@ -91,7 +91,7 @@ describe('calculateAverageHeightDebounced', () => {
         calculateAverageHeightDebounced(
             false,
             null,
-            () => ({ start: 0, end: 10 }),
+            { start: 0, end: 10 },
             mockElements,
             {},
             -1,
@@ -121,7 +121,7 @@ describe('calculateAverageHeightDebounced', () => {
         calculateAverageHeightDebounced(
             false,
             null,
-            () => ({ start: 0, end: 10 }),
+            { start: 0, end: 10 },
             mockElements,
             {},
             -1,
@@ -151,7 +151,7 @@ describe('calculateAverageHeightDebounced', () => {
         const result = calculateAverageHeightDebounced(
             true, // isCalculatingHeight = true
             null,
-            () => ({ start: 0, end: 10 }),
+            { start: 0, end: 10 },
             [],
             {},
             -1,
@@ -170,7 +170,7 @@ describe('calculateAverageHeightDebounced', () => {
         const result = calculateAverageHeightDebounced(
             false,
             existingTimeout,
-            () => ({ start: 0, end: 10 }),
+            { start: 0, end: 10 },
             [],
             {},
             -1,
@@ -192,7 +192,7 @@ describe('calculateAverageHeightDebounced', () => {
         const result = calculateAverageHeightDebounced(
             false,
             null,
-            () => ({ start: 5, end: 10 }),
+            { start: 5, end: 10 },
             [],
             {},
             5, // matches start index

--- a/src/lib/utils/heightCalculation.ts
+++ b/src/lib/utils/heightCalculation.ts
@@ -62,7 +62,7 @@ import { BROWSER } from 'esm-env'
  *
  * @param isCalculatingHeight - Flag to prevent concurrent calculations
  * @param heightUpdateTimeout - Reference to existing update timeout
- * @param visibleItemsGetter - Function to get current visible range
+ * @param visibleItems - Current visible range
  * @param itemElements - Array of DOM elements to measure
  * @param heightCache - Cache of previously measured heights with dirty tracking
  * @param lastMeasuredIndex - Index of last measured element
@@ -74,7 +74,7 @@ import { BROWSER } from 'esm-env'
 export const calculateAverageHeightDebounced = (
     isCalculatingHeight: boolean,
     heightUpdateTimeout: ReturnType<typeof setTimeout> | null,
-    visibleItemsGetter: () => { start: number; end: number },
+    visibleItems: { start: number; end: number },
     itemElements: HTMLElement[],
     heightCache: Record<number, number>,
     lastMeasuredIndex: number,
@@ -97,7 +97,7 @@ export const calculateAverageHeightDebounced = (
 ): NodeJS.Timeout | null => {
     if (!BROWSER || isCalculatingHeight) return null
 
-    const visibleRange = visibleItemsGetter()
+    const visibleRange = visibleItems
     const currentIndex = visibleRange.start
 
     if (currentIndex === lastMeasuredIndex && dirtyItems.size === 0) return null


### PR DESCRIPTION
While going through the component, I noticed that in a lot of cases, there would be derived values, that are actually functions, and thus have to be called when accessed.

For these instances, `$derived.by` can be used to directly get the return value of the function.
I don't think this has any significant impact on performance, but it does make the code a bit more readable with less indirection in my opinion