### PR TITLE
fix(virtual-list): eliminate scroll flash when item height changes

### DIFF
--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -697,7 +697,7 @@
                 })
                 heightManager.endDynamicUpdate()
             },
-            lastMeasuredIndex < 0 ? 0 : 100, // debounceTime (no debounce on first pass)
+            lastMeasuredIndex < 0 || dirtyItems.size > 0 ? 0 : 100, // debounceTime (no debounce on first pass or when dirty items exist)
             dirtyItems, // Pass dirty items for processing
             0, // Don't pass ReactiveListManager state - let each system manage its own totals
             0, // Don't pass ReactiveListManager state - let each system manage its own totals


### PR DESCRIPTION
## Summary

- Fixes the visual flash/blink when expanding or collapsing accordion items in the variable-height example after scrolling down
- **Root cause:** The 100ms debounce on `calculateAverageHeightDebounced` left stale average height values for several frames between the item height change and recalculation, causing temporary visible range and transform inconsistencies
- **Fix:** When dirty items exist (ResizeObserver-detected height changes), bypass the 100ms debounce and process immediately (0ms), eliminating the stale-render window. The 100ms debounce is preserved for normal scroll-driven measurement passes where batching is beneficial.

Closes #327

## Test plan

- [x] All 324 unit tests pass (`pnpm vitest run`)
- [x] Library builds successfully (`pnpm build`)
- [x] Manual verification: scroll to ~item 200, expand/collapse accordion — no flash/blink
- [ ] Regression check on `/docs/debug` page for `state_unsafe_mutation`
- [ ] Test at various scroll positions (near top, middle, near bottom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)