### PR TITLE
ci: migrate Cloudflare Workers deploy and improve pipeline resilience

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -1,4 +1,4 @@
-name: Cloudflare Pages - Deploy
+name: Cloudflare Workers - Deploy
 
 permissions:
     contents: read
@@ -8,7 +8,13 @@ on:
         types: [closed]
         paths:
             - docs/**
-            - .github/workflows/cloudflare-pages.yml
+            - src/**
+            - static/**
+            - package.json
+            - pnpm-lock.yaml
+            - svelte.config.js
+            - vite.config.ts
+            - .github/workflows/cloudflare-deploy.yml
         branches:
             - main
     workflow_dispatch:
@@ -17,7 +23,9 @@ on:
 
 jobs:
     deploy:
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true }}
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        environment: docs
         name: Deploy
         steps:
             - name: Checkout
@@ -33,6 +41,7 @@ jobs:
               uses: actions/setup-node@v6 # zizmor: ignore[unpinned-uses]
               with:
                   node-version: 24
+                  cache: pnpm
 
             - name: Install Root Dependencies
               run: pnpm install --frozen-lockfile
@@ -47,6 +56,7 @@ jobs:
             - name: Deploy Docs
               working-directory: docs
               env:
+                  NODE_OPTIONS: --max-old-space-size=4096
                   SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
                   CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -13,6 +13,7 @@ on:
 jobs:
     build:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
+        environment: ci
         strategy:
             matrix:
                 node-version: [20, 22, 24]

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,17 +44,21 @@ jobs:
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         outputs:
             should_run: ${{ steps.check.outputs.should_run }}
+            has_skip_label: ${{ steps.check.outputs.has_skip_label }}
         steps:
             - id: check
               env:
                   EVENT_NAME: ${{ github.event_name }}
                   PR_MERGED: ${{ github.event.pull_request.merged }}
+                  HAS_SKIP_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'skip-publish') }}
               run: |
                   if [[ "$EVENT_NAME" == "pull_request" && "$PR_MERGED" != "true" ]]; then
                       echo "should_run=false" >> $GITHUB_OUTPUT
                   else
                       echo "should_run=true" >> $GITHUB_OUTPUT
                   fi
+
+                  echo "has_skip_label=$HAS_SKIP_LABEL" >> $GITHUB_OUTPUT
 
     debug-check:
         needs: check-if-merged
@@ -245,13 +249,14 @@ jobs:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   flag-name: node-${{ matrix.node-version }}
                   parallel: true
+                  fail-on-error: false
               if: matrix.node-version == '22'
 
             # Removed dependency caching to reduce cache-poisoning risk
 
     playwright-tests:
         needs: [check-if-merged, debug-check]
-        if: needs.check-if-merged.outputs.should_run == 'true'
+        if: needs.check-if-merged.outputs.should_run == 'true' && needs.check-if-merged.outputs.has_skip_label != 'true'
         timeout-minutes: 60
         runs-on: blacksmith-4vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         environment: ci
@@ -296,7 +301,11 @@ jobs:
     # 4. Coverage reporting (depends on tests)
     coverage-report:
         needs: [check-if-merged, build, playwright-tests]
-        if: needs.check-if-merged.outputs.should_run == 'true'
+        if: |
+            always() &&
+            needs.check-if-merged.outputs.should_run == 'true' &&
+            needs.build.result == 'success' &&
+            (needs.playwright-tests.result == 'success' || needs.playwright-tests.result == 'skipped')
         runs-on: blacksmith-2vcpu-ubuntu-2404 # trunk-ignore(actionlint/runner-label)
         steps:
             - name: Coveralls Finished
@@ -304,11 +313,17 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   parallel-finished: true
+                  fail-on-error: false
 
     # 5. Publishing job (main deployment logic)
     publish-github-packages:
         needs: [check-if-merged, build, playwright-tests, coverage-report]
-        if: needs.check-if-merged.outputs.should_run == 'true'
+        if: |
+            always() &&
+            needs.check-if-merged.outputs.should_run == 'true' &&
+            needs.build.result == 'success' &&
+            (needs.playwright-tests.result == 'success' || needs.playwright-tests.result == 'skipped') &&
+            (needs.coverage-report.result == 'success' || needs.coverage-report.result == 'skipped')
         runs-on: ubuntu-latest
         environment: production
         permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ docs/static/social-cards/**
 docs/src/lib/github-stats.json
 docs/static/og-default.png
 docs/static/twitter-default.png
+/tmp

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -7,7 +7,11 @@
     "name": "svelte-page-virtuallist",
     "compatibility_date": "2026-01-20",
     "compatibility_flags": ["nodejs_als", "nodejs_compat"],
-    "pages_build_output_dir": ".svelte-kit/cloudflare",
+    "main": ".svelte-kit/cloudflare/_worker.js",
+    "assets": {
+        "directory": ".svelte-kit/cloudflare",
+        "binding": "ASSETS"
+    },
     "observability": {
         "enabled": true
     },


### PR DESCRIPTION
## Summary

Migrate Cloudflare docs deployment from Pages to Workers and improve CI pipeline resilience to prevent flaky failures from blocking publishes.

## Changes

🔄 **CI/CD**
- Rename `cloudflare-pages.yml` → `cloudflare-deploy.yml` to reflect Workers migration
- Switch wrangler config from `pages_build_output_dir` to worker entrypoint with assets binding
- Add `skip-publish` label support to bypass Playwright tests on docs-only PRs
- Use `always()` with explicit result checks so skipped/optional jobs don't block publishing
- Add `fail-on-error: false` to Coveralls steps to prevent flaky coverage uploads from failing the pipeline
- Add `ci` environment to coveralls workflow
- Add `/tmp` to `.gitignore`

## Commits

- [`0012918`](https://github.com/humanspeak/svelte-virtual-list/commit/001291802e4883fe648cd4346323bf1c69115a0c) build(docs): migrate Cloudflare Pages deployment to Workers
- [`6d80bc1`](https://github.com/humanspeak/svelte-virtual-list/commit/6d80bc1aa3f0e7e31fbef69c4d1d7dc9b4485d24) ci: add skip-publish label and improve pipeline resilience
