### PR TITLE
fix(docs): use wrangler deploy instead of wrangler pages deploy

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
         "cf-typegen": "wrangler types && mv worker-configuration.d.ts src/",
         "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
         "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-        "deploy": "pnpm run build && wrangler pages deploy",
+        "deploy": "pnpm run build && wrangler deploy",
         "dev": "vite dev",
         "format": "prettier --write .",
         "generate-social": "tsx scripts/generate-social-cards.ts",


### PR DESCRIPTION
## Summary

Fix the Cloudflare docs deployment by switching from the Pages CLI command (`wrangler pages deploy`) to the Workers CLI command (`wrangler deploy`), matching the wrangler.jsonc migration to Workers format in #391.

## Changes

🐛 **Bug fix**
- Change deploy script from `wrangler pages deploy` to `wrangler deploy` in docs/package.json

## Commits

- [`db785db`](https://github.com/humanspeak/svelte-virtual-list/commit/db785db) fix(docs): use wrangler deploy instead of wrangler pages deploy
