### PR TITLE
fix(ci): remove stale sitemap manifest step

### DIFF
--- a/.github/workflows/cloudflare-deploy.yml
+++ b/.github/workflows/cloudflare-deploy.yml
@@ -49,10 +49,6 @@ jobs:
             - name: Build Package
               run: pnpm run build
 
-            - name: Generate sitemap manifest
-              working-directory: docs
-              run: pnpm run sitemap:manifest
-
             - name: Deploy Docs
               working-directory: docs
               env:


### PR DESCRIPTION
## Summary

Removes the stale deploy workflow step that still calls `pnpm run sitemap:manifest`. That script was removed when sitemap manifest generation moved into the docs-kit Vite plugin pipeline, so the deploy job currently fails before reaching the docs deploy step.

## Changes

🔄 CI/CD

- Deletes the obsolete `Generate sitemap manifest` step from `.github/workflows/cloudflare-deploy.yml`.
- Leaves docs deployment unchanged; `pnpm run deploy` still runs the docs build, which now generates the sitemap manifest via `sitemapManifestPlugin`.

🧪 Testing

- `trunk fmt .github/workflows/cloudflare-deploy.yml`
- `trunk check .github/workflows/cloudflare-deploy.yml`
- Verified no remaining references to `sitemap:manifest` or `generate-sitemap-manifest`.

## Commits

- [`a6533f4`](https://github.com/humanspeak/svelte-virtual-list/commit/a6533f4) fix(ci): remove stale sitemap manifest step
