### PR TITLE
chore: add pnpm minimumReleaseAge (48h) supply-chain delay

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,6 @@ packages:
 
 onlyBuiltDependencies:
     - '@humanspeak/docs-kit'
+minimumReleaseAge: 2880
+minimumReleaseAgeExclude:
+    - '@humanspeak/*'


### PR DESCRIPTION
Adds a 48-hour `minimumReleaseAge` (2880 min) to the root `pnpm-workspace.yaml` so freshly published dependency versions must age before they can be installed, mitigating supply-chain attacks. Our own `@humanspeak/*` scope is excluded so first-party releases are not delayed.

```yaml
minimumReleaseAge: 2880
minimumReleaseAgeExclude:
    - '@humanspeak/*'
```

Labeled `skip-publish` (no release needed).