### PR TITLE
ci: align npm release workflows with pnpm

### DIFF
--- a/.github/workflows/npm-prerelease.yml
+++ b/.github/workflows/npm-prerelease.yml
@@ -43,6 +43,9 @@ on:
             - src/**
             - tests/**
             - package.json
+            - pnpm-lock.yaml
+            - pnpm-workspace.yaml
+            - .github/workflows/npm-prerelease.yml
 
 jobs:
     # Quick validation
@@ -64,15 +67,15 @@ jobs:
                   cache: ''
 
             - name: Install dependencies
-              run: npm ci --prefer-offline --no-audit --ignore-scripts
+              run: pnpm install --filter . --prefer-offline --frozen-lockfile --ignore-scripts --config.engine-strict=false
 
             - name: Run tests
-              run: npm test
+              run: pnpm test
 
             - name: Run E2E tests
               run: |
-                  npx playwright install --with-deps
-                  npm run test:e2e
+                  pnpm exec playwright install --with-deps
+                  pnpm run test:e2e
 
     # Prerelease publishing
     publish-prerelease:
@@ -102,7 +105,7 @@ jobs:
                   cache: ''
 
             - name: Install dependencies
-              run: npm ci --prefer-offline --no-audit --ignore-scripts
+              run: pnpm install --filter . --prefer-offline --frozen-lockfile --ignore-scripts --config.engine-strict=false
 
             - name: Import GPG key
               id: import_gpg
@@ -156,17 +159,19 @@ jobs:
                   # Check if current version already has prerelease suffix
                   if [[ "$CURRENT_VERSION" == *"-"* ]]; then
                       # Increment existing prerelease
-                      NEW_VERSION=$(npm version prerelease --preid="$TYPE" --no-git-tag-version)
+                      pnpm version prerelease --preid="$TYPE" --no-git-tag-version
                   else
                       # Create new prerelease from bumped version
-                      npm version "$BASE_BUMP" --no-git-tag-version >/dev/null
-                      NEW_VERSION=$(npm version prerelease --preid="$TYPE" --no-git-tag-version)
+                      pnpm version "$BASE_BUMP" --no-git-tag-version
+                      pnpm version prerelease --preid="$TYPE" --no-git-tag-version
                   fi
 
-                  echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  PACKAGE_VERSION=$(node -p "require('./package.json').version")
+                  NEW_VERSION="v${PACKAGE_VERSION}"
+                  echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
                   # Create stripped version without 'v' prefix for npm install commands
                   STRIPPED_VERSION=${NEW_VERSION#v}
-                  echo "stripped_version=$STRIPPED_VERSION" >> $GITHUB_OUTPUT
+                  echo "stripped_version=$STRIPPED_VERSION" >> "$GITHUB_OUTPUT"
                   echo "New prerelease version: $NEW_VERSION"
 
             - name: Commit and tag prerelease

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -21,6 +21,7 @@ on:
             - '!src/routes/**'
             - package.json
             - pnpm-lock.yaml
+            - pnpm-workspace.yaml
             - .github/workflows/npm-publish.yml
     workflow_dispatch:
         inputs:
@@ -473,9 +474,11 @@ jobs:
                       ;;
                   esac
 
-                  # Get the new version number
-                  NEW_VERSION=$(pnpm version "$BUMP_TYPE" --no-git-tag-version)
-                  echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+                  # Mutate package.json only — do NOT parse pnpm stdout (pnpm 11 prints multi-line text)
+                  pnpm version "$BUMP_TYPE" --no-git-tag-version
+                  PACKAGE_VERSION=$(node -p "require('./package.json').version")
+                  NEW_VERSION="v${PACKAGE_VERSION}"
+                  echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
                   # Escape special characters in PR title and URL
                   ESCAPED_TITLE=$(echo "$PR_TITLE" | sed 's/[`$"\]/\\&/g')


### PR DESCRIPTION
## Summary

This PR fixes release workflow version derivation so the version comes from `package.json` after mutation instead of package-manager stdout. It also brings the prerelease workflow in line with the repository's PNPM workspace setup.

## Changes

- 🔄 CI/CD
  - Read release and prerelease versions from `package.json` after `pnpm version` mutates the file.
  - Include `pnpm-workspace.yaml` in publish workflow trigger paths.
  - Include PNPM workspace, lockfile, and workflow changes in prerelease trigger paths.
  - Replace prerelease workflow `npm`/`npx` install and test commands with PNPM equivalents.

## Commits

- [`836e72e`](https://github.com/humanspeak/svelte-virtual-list/commit/836e72ebcbfc6eb7efedda5f56685076f31cd2d7) ci: align npm release workflows with pnpm
