### PR TITLE
fix(virtual-list): count collapsed margins in item height measurement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # @humanspeak/svelte-virtual-list
 
 [![NPM version](https://img.shields.io/npm/v/@humanspeak/svelte-virtual-list.svg)](https://www.npmjs.com/package/@humanspeak/svelte-virtual-list)
+[![tokenmaxing](https://tokenmaxing.app/badge/humanspeak/svelte-virtual-list)](https://tokenmaxing.app/card/humanspeak/svelte-virtual-list)
 [![Build Status](https://github.com/humanspeak/svelte-virtual-list/actions/workflows/npm-publish.yml/badge.svg)](https://github.com/humanspeak/svelte-virtual-list/actions/workflows/npm-publish.yml)
 [![Coverage Status](https://coveralls.io/repos/github/humanspeak/svelte-virtual-list/badge.svg?branch=main)](https://coveralls.io/github/humanspeak/svelte-virtual-list?branch=main)
 [![License](https://img.shields.io/npm/l/@humanspeak/svelte-virtual-list.svg)](https://github.com/humanspeak/svelte-virtual-list/blob/main/LICENSE)
@@ -238,18 +239,18 @@ This project uses [Trunk](https://trunk.io) for formatting and linting. Trunk ma
 
 Part of the [Humanspeak](https://humanspeak.com) family of runes-native Svelte 5 packages:
 
-| Package | Description |
-| --- | --- |
-| [@humanspeak/svelte-markdown](https://markdown.svelte.page) | Runtime markdown renderer for Svelte |
-| **[@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)** — _this package_ | Virtual scrolling for Svelte |
-| [@humanspeak/svelte-motion](https://motion.svelte.page) | Framer Motion for Svelte 5 |
-| [@humanspeak/svelte-headless-table](https://table.svelte.page) | Headless data tables for Svelte |
-| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page) | Diff comparison for Svelte |
-| [@humanspeak/svelte-purify](https://purify.svelte.page) | HTML sanitisation for Svelte |
-| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page) | Virtual chat viewport for Svelte 5 |
-| [@humanspeak/memory-cache](https://memory.svelte.page) | In-memory cache for TypeScript |
-| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page) | JSON tree viewer for Svelte 5 |
-| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page) | Scoped class props for Svelte |
+| Package                                                                                 | Description                          |
+| --------------------------------------------------------------------------------------- | ------------------------------------ |
+| [@humanspeak/svelte-markdown](https://markdown.svelte.page)                             | Runtime markdown renderer for Svelte |
+| **[@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)** — _this package_ | Virtual scrolling for Svelte         |
+| [@humanspeak/svelte-motion](https://motion.svelte.page)                                 | Framer Motion for Svelte 5           |
+| [@humanspeak/svelte-headless-table](https://table.svelte.page)                          | Headless data tables for Svelte      |
+| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page)                         | Diff comparison for Svelte           |
+| [@humanspeak/svelte-purify](https://purify.svelte.page)                                 | HTML sanitisation for Svelte         |
+| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page)                      | Virtual chat viewport for Svelte 5   |
+| [@humanspeak/memory-cache](https://memory.svelte.page)                                  | In-memory cache for TypeScript       |
+| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page)                       | JSON tree viewer for Svelte 5        |
+| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page)                           | Scoped class props for Svelte        |
 
 ## License
 

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -157,6 +157,7 @@
         calculateTransformY,
         calculateVisibleRange,
         clampValue,
+        measureItemPitch,
         updateHeightAndScroll as utilsUpdateHeightAndScroll
     } from '$lib/utils/virtualList.js'
     import { createDebugInfo, shouldShowDebugInfo } from '$lib/utils/virtualListDebug.js'
@@ -625,7 +626,9 @@
 
                     if (elementIndex !== -1) {
                         if (actualIndex >= 0) {
-                            const currentHeight = element.getBoundingClientRect().height
+                            // Compare pitch (not border-box height) against the
+                            // cache, which stores pitches — see measureItemPitch.
+                            const currentHeight = measureItemPitch(element)
                             const isSignificant = isSignificantHeightChange(
                                 actualIndex,
                                 currentHeight,

--- a/src/lib/utils/virtualList.ts
+++ b/src/lib/utils/virtualList.ts
@@ -244,6 +244,45 @@ export const updateHeightAndScroll = (
  *   40
  * )
  */
+/**
+ * Measures an item's layout pitch: the vertical space it actually occupies in
+ * the items container, including any margins that collapse through the
+ * component's unstyled item wrappers.
+ *
+ * A border-box measurement (`getBoundingClientRect().height`) excludes
+ * margins, and chat-bubble-style CSS (`margin: 12px 0` on rendered content)
+ * collapses through the wrapper — permanently under-counting every item and
+ * running totalHeight short (issue #412). Layout offsets are ground truth:
+ * the delta from this wrapper's top to the next sibling's top includes
+ * collapsed margins by construction. The last rendered wrapper is closed by
+ * the items container's bottom edge — the container is absolutely positioned
+ * (a block formatting context), so its auto height includes the last child's
+ * bottom margin.
+ *
+ * Known bounded residual: the leading collapsed margin above the first item
+ * belongs to no pitch — a constant ≤ one margin across the whole list,
+ * invisible to scrolling.
+ *
+ * Falls back to the border-box height when the element is not laid out
+ * (detached, display: none, or non-browser test environments where offsets
+ * read 0).
+ *
+ * @param {HTMLElement} element - The item wrapper element to measure.
+ * @returns {number} The item's layout pitch in pixels.
+ */
+export const measureItemPitch = (element: HTMLElement): number => {
+    const rect = element.getBoundingClientRect()
+    const parent = element.parentElement
+    if (!parent) return rect.height
+
+    const next = element.nextElementSibling
+    const pitch = next
+        ? next.getBoundingClientRect().top - rect.top
+        : parent.getBoundingClientRect().bottom - rect.top
+
+    return pitch > 0 ? pitch : rect.height
+}
+
 export const calculateAverageHeight = (
     itemElements: HTMLElement[],
     visibleRange: { start: number; end: number },
@@ -298,7 +337,7 @@ export const calculateAverageHeight = (
                 try {
                     // await tick()
                     void element.offsetHeight
-                    const height = element.getBoundingClientRect().height
+                    const height = measureItemPitch(element)
                     const oldHeight = newHeightCache[itemIndex]
                     if (Number.isFinite(height) && height > 0) {
                         // Only update if height actually changed (use smaller tolerance for precision)
@@ -341,7 +380,7 @@ export const calculateAverageHeight = (
             const itemIndex = visibleRange.start + i
             if (!newHeightCache[itemIndex]) {
                 try {
-                    const height = el.getBoundingClientRect().height
+                    const height = measureItemPitch(el)
                     if (Number.isFinite(height) && height > 0) {
                         // Add new height to running totals
                         totalValidHeight += height

--- a/src/routes/tests/issues/issue-412/+page.svelte
+++ b/src/routes/tests/issues/issue-412/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import { onMount } from 'svelte'
     import SvelteVirtualList from '$lib/index.js'
 
     type Item = {
@@ -13,24 +14,358 @@
     // is 112px. The estimate is pinned to the border box (100) so any height
     // the cache learns beyond that must come from measuring margins.
     const ITEM_COUNT = 500
+    const BORDER_BOX_PX = 100
+    const MARGIN_PX = 12
+    const REAL_PITCH_PX = BORDER_BOX_PX + MARGIN_PX
+    const SWEEP_STEPS = 25
+    const PITCH_TOLERANCE_PX = 1.5
+    const JUMP_TOLERANCE_PX = 3
 
     const items: Item[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
         id: i,
         text: `Item ${i}`
     }))
+
+    type SweepResult = {
+        jumps: number
+        maxJumpPx: number
+        totalJumpPx: number
+        samples: number
+    }
+
+    let realPitch = $state<number | null>(null)
+    let cachePitch = $state<number | null>(null)
+    let scrollHeightPx = $state<number | null>(null)
+    let sweep = $state<SweepResult | null>(null)
+    let sweepRunning = $state(false)
+
+    const marginLossPx = $derived(
+        realPitch !== null && cachePitch !== null
+            ? Math.round((realPitch - cachePitch) * 10) / 10
+            : null
+    )
+    const expectedScrollHeight = $derived(realPitch !== null ? ITEM_COUNT * realPitch : null)
+    const missingPx = $derived(
+        expectedScrollHeight !== null && scrollHeightPx !== null
+            ? expectedScrollHeight - scrollHeightPx
+            : null
+    )
+
+    const pitchPass = $derived(
+        realPitch !== null &&
+            cachePitch !== null &&
+            Math.abs(cachePitch - realPitch) <= PITCH_TOLERANCE_PX
+    )
+    const sweepPass = $derived(sweep !== null && sweep.maxJumpPx <= JUMP_TOLERANCE_PX)
+
+    const getViewport = (): HTMLElement | null =>
+        document.querySelector('[data-testid="issue-412-list-viewport"]')
+
+    const nextFrame = () => new Promise<void>((r) => requestAnimationFrame(() => r()))
+
+    const measurePitchStats = () => {
+        const viewport = getViewport()
+        if (!viewport) return
+        const wrappers = Array.from(
+            viewport.querySelectorAll('[data-original-index]')
+        ) as HTMLElement[]
+        if (wrappers.length >= 2) {
+            realPitch = wrappers[1].offsetTop - wrappers[0].offsetTop
+        }
+        scrollHeightPx = viewport.scrollHeight
+        cachePitch = Math.round((viewport.scrollHeight / ITEM_COUNT) * 10) / 10
+    }
+
+    /**
+     * Constant-rate scroll sweep: scroll exactly one pitch per step and track
+     * a mid-window item across frames. Content must move by exactly the
+     * scrolled distance — any deviation is a painted jump the user sees.
+     */
+    const runSweep = async () => {
+        const viewport = getViewport()
+        if (!viewport || sweepRunning) return
+        sweepRunning = true
+        sweep = null
+
+        viewport.scrollTop = 2000
+        await nextFrame()
+        await nextFrame()
+
+        const rectTopOf = (index: number): number | null => {
+            const el = viewport.querySelector(
+                `[data-original-index="${index}"]`
+            ) as HTMLElement | null
+            return el ? el.getBoundingClientRect().top : null
+        }
+        const midRenderedIndex = (): number => {
+            const rendered = Array.from(
+                viewport.querySelectorAll('[data-original-index]')
+            ) as HTMLElement[]
+            return parseInt(
+                rendered[Math.floor(rendered.length / 2)]?.dataset.originalIndex ?? '-1',
+                10
+            )
+        }
+
+        let trackedIndex = midRenderedIndex()
+        const result: SweepResult = { jumps: 0, maxJumpPx: 0, totalJumpPx: 0, samples: 0 }
+
+        for (let step = 0; step < SWEEP_STEPS; step++) {
+            if (rectTopOf(trackedIndex) === null) trackedIndex = midRenderedIndex()
+
+            const before = rectTopOf(trackedIndex)
+            viewport.scrollTop += REAL_PITCH_PX
+            await nextFrame()
+            await nextFrame()
+            const after = rectTopOf(trackedIndex)
+
+            if (before === null || after === null) continue
+            const jump = Math.abs(after - before + REAL_PITCH_PX)
+            if (jump > 1) result.jumps++
+            result.maxJumpPx = Math.max(result.maxJumpPx, Math.round(jump * 10) / 10)
+            result.totalJumpPx = Math.round((result.totalJumpPx + jump) * 10) / 10
+            result.samples++
+        }
+
+        sweep = result
+        sweepRunning = false
+        // Re-sample totals after the sweep — measuring while scrolled deep
+        // reflects what the cache has learned across the swept range.
+        measurePitchStats()
+    }
+
+    const remeasure = async () => {
+        const viewport = getViewport()
+        if (viewport) {
+            viewport.scrollTop = 0
+            await nextFrame()
+            await nextFrame()
+        }
+        measurePitchStats()
+        await runSweep()
+    }
+
+    onMount(() => {
+        // Let the post-hydration measurement pass and debounced height
+        // recalculation settle before sampling geometry.
+        const timer = setTimeout(remeasure, 800)
+        return () => clearTimeout(timer)
+    })
 </script>
 
-<div class="test-container" style="height: 500px;">
-    <SvelteVirtualList defaultEstimatedItemHeight={100} {items} testId="issue-412-list">
-        {#snippet renderItem(item)}
-            <div class="margin-item" data-testid="margin-item-{item.id}">
-                {item.text}
-            </div>
-        {/snippet}
-    </SvelteVirtualList>
+<div class="page">
+    <h1>Issue #412 — item margins escape height measurement</h1>
+
+    <div class="description">
+        <p>
+            <strong>What:</strong> 500 items, each a <code>{BORDER_BOX_PX}px</code> border box with
+            <code>margin: {MARGIN_PX}px 0</code>. The margins collapse through the component's
+            unstyled item wrappers, so the real layout pitch is
+            <strong>{REAL_PITCH_PX}px</strong> while a border-box measurement reads
+            <strong>{BORDER_BOX_PX}px</strong>. The height estimate is pinned to the border box, so
+            any pitch the cache learns beyond {BORDER_BOX_PX}px must come from measuring margins.
+        </p>
+        <p>
+            <strong>Why it's bad:</strong> when margins escape, <code>totalHeight</code> runs
+            {MARGIN_PX}px/item short (−{ITEM_COUNT * MARGIN_PX}px of scrollable content on this
+            fixture) and content visibly jumps by the lost margin every time the render-range
+            boundary advances while scrolling — a {MARGIN_PX}px sawtooth, roughly once per item.
+        </p>
+        <p>
+            <strong>How it's measured:</strong> real pitch is the <code>offsetTop</code> delta
+            between neighboring rendered wrappers (layout ground truth); cache pitch is
+            <code>scrollHeight ÷ {ITEM_COUNT}</code> (what the component believes). The sweep scrolls
+            exactly one pitch per step and tracks a mid-window item — any deviation between scrolled distance
+            and painted movement is a jump the user sees.
+        </p>
+    </div>
+
+    <div class="stats" data-testid="issue-412-stats">
+        <div
+            class="stat"
+            class:pass={realPitch === REAL_PITCH_PX}
+            class:fail={realPitch !== null && realPitch !== REAL_PITCH_PX}
+        >
+            <span class="light"
+                >{realPitch === null ? '…' : realPitch === REAL_PITCH_PX ? '✓' : '✗'}</span
+            >
+            <span class="label">real layout pitch</span>
+            <span class="value" data-testid="stat-real-pitch">{realPitch ?? '—'}px</span>
+            <span class="expected">fixture sanity: must be {REAL_PITCH_PX}px</span>
+        </div>
+
+        <div class="stat" class:pass={pitchPass} class:fail={cachePitch !== null && !pitchPass}>
+            <span class="light">{cachePitch === null ? '…' : pitchPass ? '✓' : '✗'}</span>
+            <span class="label">cache-implied pitch</span>
+            <span class="value" data-testid="stat-cache-pitch">{cachePitch ?? '—'}px</span>
+            <span class="expected">must match real pitch ±{PITCH_TOLERANCE_PX}px</span>
+        </div>
+
+        <div class="stat" class:pass={pitchPass} class:fail={marginLossPx !== null && !pitchPass}>
+            <span class="light">{marginLossPx === null ? '…' : pitchPass ? '✓' : '✗'}</span>
+            <span class="label">margin loss per item</span>
+            <span class="value" data-testid="stat-margin-loss">{marginLossPx ?? '—'}px</span>
+            <span class="expected">should be 0px — {MARGIN_PX}px means the margin escaped</span>
+        </div>
+
+        <div class="stat" class:pass={pitchPass} class:fail={missingPx !== null && !pitchPass}>
+            <span class="light">{missingPx === null ? '…' : pitchPass ? '✓' : '✗'}</span>
+            <span class="label">missing scrollable content</span>
+            <span class="value" data-testid="stat-missing-px">{missingPx ?? '—'}px</span>
+            <span class="expected"
+                >scrollHeight {scrollHeightPx ?? '—'}px vs real {expectedScrollHeight ??
+                    '—'}px</span
+            >
+        </div>
+
+        <div class="stat" class:pass={sweepPass} class:fail={sweep !== null && !sweepPass}>
+            <span class="light"
+                >{sweep === null ? (sweepRunning ? '⟳' : '…') : sweepPass ? '✓' : '✗'}</span
+            >
+            <span class="label">painted jumps during sweep</span>
+            <span class="value" data-testid="stat-sweep">
+                {#if sweep}
+                    jumps={sweep.jumps} maxJumpPx={sweep.maxJumpPx} totalJumpPx={sweep.totalJumpPx}
+                    samples={sweep.samples}
+                {:else if sweepRunning}
+                    running…
+                {:else}
+                    —
+                {/if}
+            </span>
+            <span class="expected"
+                >maxJumpPx must be ≤{JUMP_TOLERANCE_PX}px over {SWEEP_STEPS} one-pitch steps</span
+            >
+        </div>
+
+        <button class="remeasure" onclick={remeasure} disabled={sweepRunning}>
+            {sweepRunning ? 'sweeping…' : 'Re-measure'}
+        </button>
+    </div>
+
+    <div class="test-container" style="height: 500px;">
+        <SvelteVirtualList defaultEstimatedItemHeight={100} {items} testId="issue-412-list">
+            {#snippet renderItem(item)}
+                <div class="margin-item" data-testid="margin-item-{item.id}">
+                    {item.text}
+                </div>
+            {/snippet}
+        </SvelteVirtualList>
+    </div>
 </div>
 
 <style>
+    .page {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 16px;
+        font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
+    }
+
+    h1 {
+        font-size: 18px;
+        margin: 0 0 12px;
+    }
+
+    .description {
+        font-size: 13px;
+        line-height: 1.5;
+        color: #333;
+        background: #fafafa;
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 4px 14px;
+        margin-bottom: 12px;
+    }
+
+    .description code {
+        background: #eef2f7;
+        padding: 1px 4px;
+        border-radius: 3px;
+    }
+
+    .stats {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 12px;
+        font-size: 13px;
+    }
+
+    .stat {
+        display: grid;
+        grid-template-columns: 22px 190px minmax(120px, auto) 1fr;
+        gap: 8px;
+        align-items: baseline;
+        padding: 6px 10px;
+        border-radius: 6px;
+        border: 1px solid #e5e5e5;
+        background: #f6f6f6;
+    }
+
+    .stat.pass {
+        background: #e9f7ee;
+        border-color: #b7e2c4;
+    }
+
+    .stat.fail {
+        background: #fdeaea;
+        border-color: #f2b8b8;
+    }
+
+    .light {
+        font-weight: 700;
+    }
+
+    .stat.pass .light {
+        color: #1a7f37;
+    }
+
+    .stat.fail .light {
+        color: #c62828;
+    }
+
+    .label {
+        font-weight: 600;
+    }
+
+    .value {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+    }
+
+    .stat.pass .value {
+        color: #1a7f37;
+    }
+
+    .stat.fail .value {
+        color: #c62828;
+    }
+
+    .expected {
+        color: #777;
+        font-size: 12px;
+    }
+
+    .remeasure {
+        align-self: flex-start;
+        margin-top: 4px;
+        padding: 6px 14px;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 13px;
+    }
+
+    .remeasure:disabled {
+        opacity: 0.6;
+        cursor: wait;
+    }
+
     .test-container {
         width: 100%;
         border: 1px solid #eee;

--- a/src/routes/tests/issues/issue-412/+page.svelte
+++ b/src/routes/tests/issues/issue-412/+page.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+    import SvelteVirtualList from '$lib/index.js'
+
+    type Item = {
+        id: number
+        text: string
+    }
+
+    // Fixed-size items whose ONLY variable is the CSS margin: content is a
+    // 100px border box with margin: 12px 0. The margins collapse through the
+    // component's unstyled item wrappers, so a border-box measurement reads
+    // 100px while the real layout pitch (offsetTop delta between neighbors)
+    // is 112px. The estimate is pinned to the border box (100) so any height
+    // the cache learns beyond that must come from measuring margins.
+    const ITEM_COUNT = 500
+
+    const items: Item[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    }))
+</script>
+
+<div class="test-container" style="height: 500px;">
+    <SvelteVirtualList defaultEstimatedItemHeight={100} {items} testId="issue-412-list">
+        {#snippet renderItem(item)}
+            <div class="margin-item" data-testid="margin-item-{item.id}">
+                {item.text}
+            </div>
+        {/snippet}
+    </SvelteVirtualList>
+</div>
+
+<style>
+    .test-container {
+        width: 100%;
+        border: 1px solid #eee;
+    }
+
+    .margin-item {
+        box-sizing: border-box;
+        height: 100px;
+        margin: 12px 0;
+        padding: 8px;
+        background: #e8f0fe;
+        border-radius: 8px;
+        font-size: 14px;
+    }
+</style>

--- a/tests/issues/issue-412.spec.ts
+++ b/tests/issues/issue-412.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test } from '@playwright/test'
+import { rafWait } from '../../src/lib/test/utils/rafWait.js'
+
+const VIEWPORT_SELECTOR = '[data-testid="issue-412-list-viewport"]'
+
+/**
+ * Issue #412 — Item margins escape height measurement
+ *
+ * Item heights are measured as the wrapper's border box, which excludes
+ * margins. The fixture's items are a 100px border box with margin: 12px 0
+ * that collapses through the component's unstyled item wrappers, so the
+ * real layout pitch (offsetTop delta between neighboring wrappers) is
+ * 112px while the height cache reads 100px.
+ *
+ * Consequences pinned by these specs:
+ * 1. totalHeight (viewport scrollHeight) runs ~12px/item short — the
+ *    cache-implied pitch disagrees with the rendered layout pitch.
+ * 2. While scrolling, content visibly jumps by the lost margin whenever
+ *    the render-range start advances: the items container is translated
+ *    by cache offsets (100/item) while real content stacks at 112/item.
+ */
+
+const ITEM_COUNT = 500
+const BORDER_BOX_PX = 100
+const MARGIN_PX = 12
+const REAL_PITCH_PX = BORDER_BOX_PX + MARGIN_PX
+
+/** Real layout pitch: offsetTop delta between consecutive rendered wrappers. */
+const measureRealPitch = (selector: string): number | null => {
+    const viewport = document.querySelector(selector) as HTMLElement | null
+    if (!viewport) return null
+    const wrappers = Array.from(viewport.querySelectorAll('[data-original-index]')) as HTMLElement[]
+    if (wrappers.length < 2) return null
+    return wrappers[1].offsetTop - wrappers[0].offsetTop
+}
+
+test.describe('Issue 412 - margins escape item height measurement', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/issues/issue-412', { waitUntil: 'domcontentloaded' })
+        await page
+            .locator('[data-original-index]')
+            .first()
+            .waitFor({ state: 'attached', timeout: 5000 })
+        // Let the post-hydration measurement pass and debounced height
+        // recalculation settle before sampling geometry.
+        await rafWait(page, 5)
+    })
+
+    /**
+     * The pitch implied by the height cache (scrollHeight / itemCount) must
+     * match the rendered layout pitch. Pre-fix: cache pitch reads ~100px
+     * (border box) while the layout pitch is 112px — totalHeight runs
+     * ~6,000px short on this fixture.
+     */
+    test('cache-implied pitch should match rendered layout pitch', async ({ page }) => {
+        // Sanity: the fixture really produces a 112px pitch (collapsed margins).
+        const realPitch = await page.evaluate(measureRealPitch, VIEWPORT_SELECTOR)
+        expect(realPitch).toBe(REAL_PITCH_PX)
+
+        // Wait until measurements have settled (scrollHeight stable across frames).
+        await expect
+            .poll(
+                async () => {
+                    const before = await page.evaluate(
+                        (sel) => document.querySelector(sel)?.scrollHeight ?? 0,
+                        VIEWPORT_SELECTOR
+                    )
+                    await rafWait(page, 3)
+                    const after = await page.evaluate(
+                        (sel) => document.querySelector(sel)?.scrollHeight ?? 0,
+                        VIEWPORT_SELECTOR
+                    )
+                    return after - before
+                },
+                { timeout: 5000 }
+            )
+            .toBe(0)
+
+        const scrollHeight = await page.evaluate(
+            (sel) => document.querySelector(sel)?.scrollHeight ?? 0,
+            VIEWPORT_SELECTOR
+        )
+        const cachePitch = scrollHeight / ITEM_COUNT
+
+        // Allow a bounded residual: the leading collapsed margin belongs to no
+        // pitch (a constant ≤ one margin across the whole list).
+        expect(Math.abs(cachePitch - REAL_PITCH_PX)).toBeLessThanOrEqual(1.5)
+    })
+
+    /**
+     * Scrolling one pitch at a time must move content by exactly one pitch.
+     * Pre-fix: every time the render-range start advances, the items
+     * container is re-anchored using cached (margin-less) offsets, so a
+     * tracked item visibly jumps by the lost 12px margin per boundary.
+     */
+    test('content should not jump at render-range boundaries while scrolling', async ({ page }) => {
+        const result = await page.evaluate(
+            async ({ selector, pitch, steps }) => {
+                const viewport = document.querySelector(selector) as HTMLElement | null
+                if (!viewport) return { error: 'no viewport', maxJumpPx: -1, samples: 0 }
+
+                const nextFrame = () =>
+                    new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+                // Start mid-list so range boundaries are crossed on every step.
+                viewport.scrollTop = 2000
+                await nextFrame()
+                await nextFrame()
+
+                const rectTopOf = (index: number): number | null => {
+                    const el = viewport.querySelector(
+                        `[data-original-index="${index}"]`
+                    ) as HTMLElement | null
+                    return el ? el.getBoundingClientRect().top : null
+                }
+
+                // Track the middle rendered item so it stays attached while
+                // the window advances behind it.
+                const rendered = Array.from(
+                    viewport.querySelectorAll('[data-original-index]')
+                ) as HTMLElement[]
+                if (rendered.length < 3)
+                    return { error: 'too few items', maxJumpPx: -1, samples: 0 }
+                let trackedIndex = parseInt(
+                    rendered[Math.floor(rendered.length / 2)].dataset.originalIndex ?? '-1',
+                    10
+                )
+
+                let maxJumpPx = 0
+                let samples = 0
+
+                for (let step = 0; step < steps; step++) {
+                    // Re-anchor to a middle rendered item when the tracked one
+                    // is about to leave the window.
+                    if (rectTopOf(trackedIndex) === null) {
+                        const current = Array.from(
+                            viewport.querySelectorAll('[data-original-index]')
+                        ) as HTMLElement[]
+                        trackedIndex = parseInt(
+                            current[Math.floor(current.length / 2)]?.dataset.originalIndex ?? '-1',
+                            10
+                        )
+                    }
+
+                    const before = rectTopOf(trackedIndex)
+                    viewport.scrollTop += pitch
+                    await nextFrame()
+                    await nextFrame()
+                    const after = rectTopOf(trackedIndex)
+
+                    if (before === null || after === null) continue
+                    // Content scrolled up by `pitch`; any deviation is a painted jump.
+                    const jump = Math.abs(after - before + pitch)
+                    maxJumpPx = Math.max(maxJumpPx, jump)
+                    samples++
+                }
+
+                return { error: null, maxJumpPx, samples }
+            },
+            { selector: VIEWPORT_SELECTOR, pitch: REAL_PITCH_PX, steps: 25 }
+        )
+
+        expect(result.error).toBeNull()
+        // Ensure the sweep actually measured movement rather than vacuously passing.
+        expect(result.samples).toBeGreaterThan(15)
+        // Pre-fix this reads ~12px (one lost margin) or a multiple of it.
+        expect(result.maxJumpPx).toBeLessThanOrEqual(3)
+    })
+})

--- a/tests/issues/issue-412.spec.ts
+++ b/tests/issues/issue-412.spec.ts
@@ -1,169 +1,84 @@
-import { expect, test } from '@playwright/test'
-import { rafWait } from '../../src/lib/test/utils/rafWait.js'
-
-const VIEWPORT_SELECTOR = '[data-testid="issue-412-list-viewport"]'
+import { expect, test, type Page } from '@playwright/test'
 
 /**
  * Issue #412 — Item margins escape height measurement
  *
- * Item heights are measured as the wrapper's border box, which excludes
+ * Item heights were measured as the wrapper's border box, which excludes
  * margins. The fixture's items are a 100px border box with margin: 12px 0
  * that collapses through the component's unstyled item wrappers, so the
  * real layout pitch (offsetTop delta between neighboring wrappers) is
- * 112px while the height cache reads 100px.
+ * 112px while a border-box measurement reads 100px.
  *
- * Consequences pinned by these specs:
- * 1. totalHeight (viewport scrollHeight) runs ~12px/item short — the
- *    cache-implied pitch disagrees with the rendered layout pitch.
- * 2. While scrolling, content visibly jumps by the lost margin whenever
- *    the render-range start advances: the items container is translated
- *    by cache offsets (100/item) while real content stacks at 112/item.
+ * The fixture at /tests/issues/issue-412 measures everything itself and
+ * reports live pass/fail stats; these specs assert on those numbers so the
+ * page a human debugs and the numbers CI enforces can never diverge.
+ *
+ * Consequences pinned:
+ * 1. totalHeight ran ~12px/item short — cache-implied pitch (scrollHeight
+ *    ÷ itemCount) disagreed with the rendered layout pitch by exactly the
+ *    lost margin (pre-fix: marginLoss=12px, 6,000px of content missing).
+ * 2. Content visibly jumped by the lost margin whenever the render-range
+ *    start advanced while scrolling (pre-fix: maxJumpPx=24, totalJumpPx=324
+ *    across a 25-step one-pitch-per-step sweep).
  */
 
-const ITEM_COUNT = 500
-const BORDER_BOX_PX = 100
-const MARGIN_PX = 12
-const REAL_PITCH_PX = BORDER_BOX_PX + MARGIN_PX
+const REAL_PITCH_PX = 112
+const PITCH_TOLERANCE_PX = 1.5
+const JUMP_TOLERANCE_PX = 3
+const MIN_SWEEP_SAMPLES = 15
 
-/** Real layout pitch: offsetTop delta between consecutive rendered wrappers. */
-const measureRealPitch = (selector: string): number | null => {
-    const viewport = document.querySelector(selector) as HTMLElement | null
-    if (!viewport) return null
-    const wrappers = Array.from(viewport.querySelectorAll('[data-original-index]')) as HTMLElement[]
-    if (wrappers.length < 2) return null
-    return wrappers[1].offsetTop - wrappers[0].offsetTop
+const stat = (name: string) => `[data-testid="stat-${name}"]`
+
+const readPx = async (page: Page, name: string): Promise<number> =>
+    parseFloat((await page.locator(stat(name)).innerText()).replace('px', ''))
+
+/** Parse the sweep stats line, e.g. "jumps=0 maxJumpPx=0 totalJumpPx=0 samples=24". */
+const readSweep = async (page: Page): Promise<Record<string, number>> => {
+    const text = await page.locator(stat('sweep')).innerText()
+    return Object.fromEntries(
+        [...text.matchAll(/(\w+)=([\d.]+)/g)].map((m) => [m[1], parseFloat(m[2])])
+    )
 }
 
 test.describe('Issue 412 - margins escape item height measurement', () => {
     test.beforeEach(async ({ page }) => {
         await page.goto('/tests/issues/issue-412', { waitUntil: 'domcontentloaded' })
-        await page
-            .locator('[data-original-index]')
-            .first()
-            .waitFor({ state: 'attached', timeout: 5000 })
-        // Let the post-hydration measurement pass and debounced height
-        // recalculation settle before sampling geometry.
-        await rafWait(page, 5)
+        // The fixture auto-measures after the component's measurement pass
+        // settles, then runs its scroll sweep; wait for the full cycle.
+        await expect(page.locator(stat('sweep'))).toContainText('maxJumpPx=', {
+            timeout: 15000
+        })
     })
 
     /**
-     * The pitch implied by the height cache (scrollHeight / itemCount) must
-     * match the rendered layout pitch. Pre-fix: cache pitch reads ~100px
-     * (border box) while the layout pitch is 112px — totalHeight runs
-     * ~6,000px short on this fixture.
+     * The pitch implied by the height cache must match the rendered layout
+     * pitch. Pre-fix: marginLoss reads exactly 12px (the collapsed margin)
+     * and 6,000px of scrollable content is missing on this fixture.
      */
     test('cache-implied pitch should match rendered layout pitch', async ({ page }) => {
-        // Sanity: the fixture really produces a 112px pitch (collapsed margins).
-        const realPitch = await page.evaluate(measureRealPitch, VIEWPORT_SELECTOR)
-        expect(realPitch).toBe(REAL_PITCH_PX)
+        // Fixture sanity: the collapsed margins really are in the layout.
+        expect(await readPx(page, 'real-pitch')).toBe(REAL_PITCH_PX)
 
-        // Wait until measurements have settled (scrollHeight stable across frames).
-        await expect
-            .poll(
-                async () => {
-                    const before = await page.evaluate(
-                        (sel) => document.querySelector(sel)?.scrollHeight ?? 0,
-                        VIEWPORT_SELECTOR
-                    )
-                    await rafWait(page, 3)
-                    const after = await page.evaluate(
-                        (sel) => document.querySelector(sel)?.scrollHeight ?? 0,
-                        VIEWPORT_SELECTOR
-                    )
-                    return after - before
-                },
-                { timeout: 5000 }
-            )
-            .toBe(0)
-
-        const scrollHeight = await page.evaluate(
-            (sel) => document.querySelector(sel)?.scrollHeight ?? 0,
-            VIEWPORT_SELECTOR
-        )
-        const cachePitch = scrollHeight / ITEM_COUNT
+        const cachePitch = await readPx(page, 'cache-pitch')
+        expect(Math.abs(cachePitch - REAL_PITCH_PX)).toBeLessThanOrEqual(PITCH_TOLERANCE_PX)
 
         // Allow a bounded residual: the leading collapsed margin belongs to no
         // pitch (a constant ≤ one margin across the whole list).
-        expect(Math.abs(cachePitch - REAL_PITCH_PX)).toBeLessThanOrEqual(1.5)
+        expect(Math.abs(await readPx(page, 'margin-loss'))).toBeLessThanOrEqual(PITCH_TOLERANCE_PX)
     })
 
     /**
      * Scrolling one pitch at a time must move content by exactly one pitch.
-     * Pre-fix: every time the render-range start advances, the items
-     * container is re-anchored using cached (margin-less) offsets, so a
-     * tracked item visibly jumps by the lost 12px margin per boundary.
+     * Pre-fix: every time the render-range start advanced, the items
+     * container was re-anchored using cached (margin-less) offsets, so the
+     * fixture's tracked item jumped by the lost 12px margin per boundary.
      */
     test('content should not jump at render-range boundaries while scrolling', async ({ page }) => {
-        const result = await page.evaluate(
-            async ({ selector, pitch, steps }) => {
-                const viewport = document.querySelector(selector) as HTMLElement | null
-                if (!viewport) return { error: 'no viewport', maxJumpPx: -1, samples: 0 }
+        const sweep = await readSweep(page)
 
-                const nextFrame = () =>
-                    new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
-
-                // Start mid-list so range boundaries are crossed on every step.
-                viewport.scrollTop = 2000
-                await nextFrame()
-                await nextFrame()
-
-                const rectTopOf = (index: number): number | null => {
-                    const el = viewport.querySelector(
-                        `[data-original-index="${index}"]`
-                    ) as HTMLElement | null
-                    return el ? el.getBoundingClientRect().top : null
-                }
-
-                // Track the middle rendered item so it stays attached while
-                // the window advances behind it.
-                const rendered = Array.from(
-                    viewport.querySelectorAll('[data-original-index]')
-                ) as HTMLElement[]
-                if (rendered.length < 3)
-                    return { error: 'too few items', maxJumpPx: -1, samples: 0 }
-                let trackedIndex = parseInt(
-                    rendered[Math.floor(rendered.length / 2)].dataset.originalIndex ?? '-1',
-                    10
-                )
-
-                let maxJumpPx = 0
-                let samples = 0
-
-                for (let step = 0; step < steps; step++) {
-                    // Re-anchor to a middle rendered item when the tracked one
-                    // is about to leave the window.
-                    if (rectTopOf(trackedIndex) === null) {
-                        const current = Array.from(
-                            viewport.querySelectorAll('[data-original-index]')
-                        ) as HTMLElement[]
-                        trackedIndex = parseInt(
-                            current[Math.floor(current.length / 2)]?.dataset.originalIndex ?? '-1',
-                            10
-                        )
-                    }
-
-                    const before = rectTopOf(trackedIndex)
-                    viewport.scrollTop += pitch
-                    await nextFrame()
-                    await nextFrame()
-                    const after = rectTopOf(trackedIndex)
-
-                    if (before === null || after === null) continue
-                    // Content scrolled up by `pitch`; any deviation is a painted jump.
-                    const jump = Math.abs(after - before + pitch)
-                    maxJumpPx = Math.max(maxJumpPx, jump)
-                    samples++
-                }
-
-                return { error: null, maxJumpPx, samples }
-            },
-            { selector: VIEWPORT_SELECTOR, pitch: REAL_PITCH_PX, steps: 25 }
-        )
-
-        expect(result.error).toBeNull()
         // Ensure the sweep actually measured movement rather than vacuously passing.
-        expect(result.samples).toBeGreaterThan(15)
-        // Pre-fix this reads ~12px (one lost margin) or a multiple of it.
-        expect(result.maxJumpPx).toBeLessThanOrEqual(3)
+        expect(sweep.samples).toBeGreaterThan(MIN_SWEEP_SAMPLES)
+        expect(sweep.jumps).toBe(0)
+        expect(sweep.maxJumpPx).toBeLessThanOrEqual(JUMP_TOLERANCE_PX)
     })
 })


### PR DESCRIPTION
## Summary

Item heights were measured as the wrapper's border box, which excludes margins — and consumer margins (the near-universal `margin: 12px 0` style) collapse straight through the component's unstyled item wrappers, so every margined item was permanently under-counted by its effective margin. On the reference fixture `totalHeight` ran 6,000px short (12px × 500 items) and the rendered slice visibly jumped by the lost margin at **every render-range boundary while scrolling**, with no ResizeObserver event to hook a correction on (the border-box heights were "stable" — just wrong). This PR derives heights from layout ground truth instead: each wrapper's `offsetTop` delta to its next sibling, which includes collapsed margins by construction, whatever CSS consumers use.

Fixes #412

## Changes

- 🐛 **Offset-delta pitch measurement** — `measureItemPitch` (in `utils/virtualList.ts`) derives each rendered item's pitch from its wrapper's offset delta to the next sibling; the last rendered wrapper is closed by the items container's bottom edge (the container is absolutely positioned — a block formatting context — so its auto height includes the last child's bottom margin). Used at all three measurement sites: both paths inside `calculateAverageHeight` and the ResizeObserver significance check in the component (the cache now stores pitches, so comparing a border-box reading against it would mark every margined item permanently dirty). The known bounded residual (the leading collapsed margin belongs to no pitch — a constant ≤ one margin, invisible to scrolling) is documented at the mechanism and tolerated in the spec.
- 🧪 **Self-reporting fixture + spec** — `/tests/issues/issue-412`: 500 items, 100px border box with 12px margins, estimate pinned to the border box so margins are the only variable. The page carries a what/why/how description and five live red/green stat rows — real layout pitch, cache-implied pitch, `marginLossPx`, missing scrollable content, and `jumps / maxJumpPx / totalJumpPx` from a self-driven one-pitch-per-step scroll sweep — plus a Re-measure button. The Playwright spec asserts on the fixture's own stat values (via `data-testid`s), so the page a human debugs and the numbers CI enforces can never diverge. Pre-fix it reads `marginLossPx=12`, 6,000px missing, `maxJumpPx=24`, `totalJumpPx=324`; post-fix all zeros. The spec was re-verified to still fail against the pre-fix component after the stats rewiring.
- 📚 **README** — tokenmaxing badge added (second badge slot).

Margin-less consumers are numerically unaffected — offset-delta pitch equals border-box height when nothing escapes — and `measureItemPitch` falls back to the border box when the element is not laid out (detached / non-browser test environments), which is why the jsdom unit suite passes untouched.

## Verification

314 unit tests, `svelte-check` clean, and the full Playwright suite green on chromium (64 passed), firefox, and webkit (128 passed combined). The issue-412 spec was additionally verified in both directions: failing on the pre-fix component (exactly `marginLossPx=12` / `maxJumpPx=24`), passing post-fix on all three engines.

## Commits

- [`6b1bb5f`](https://github.com/humanspeak/svelte-virtual-list/commit/6b1bb5f22ccd294f5a84aee830c79c49b86c28ca) test(virtual-list): add failing spec for margins escaping height measurement (#412)
- [`f42494a`](https://github.com/humanspeak/svelte-virtual-list/commit/f42494aa813512e812c4ed9e79f78783f597aa4e) fix(virtual-list): measure item pitch from layout offsets so margins can't escape (#412)
- [`64424ef`](https://github.com/humanspeak/svelte-virtual-list/commit/64424ef800e0b6a93336d53b123c3c132012b6ba) docs(readme): add tokenmaxing badge
- [`eb8489e`](https://github.com/humanspeak/svelte-virtual-list/commit/eb8489e4970946b56fbefddd619fe3eb1bff441f) test(virtual-list): report live pass/fail stats on the issue-412 fixture (#412)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
