### PR TITLE
feat(virtual-list): keyboard-accessible viewport with labeled region

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A high-performance virtual list component for Svelte 5 applications that efficie
 - 🚀 Progressive initialization for large datasets
 - 🕹️ Programmatic scrolling with `scroll`
 - ♾️ Infinite scroll support with `onLoadMore`
+- ♿ Keyboard-accessible viewport (focusable labeled region, standard scroll keys)
 
 ## Requirements
 
@@ -70,20 +71,21 @@ yarn add @humanspeak/svelte-virtual-list
 
 ## Props
 
-| Prop                         | Type                          | Default  | Description                                                                   |
-| ---------------------------- | ----------------------------- | -------- | ----------------------------------------------------------------------------- |
-| `items`                      | `T[]`                         | Required | Array of items to render                                                      |
-| `defaultEstimatedItemHeight` | `number`                      | `40`     | Initial height estimate used until items are measured                         |
-| `bufferSize`                 | `number`                      | `20`     | Number of items rendered outside the viewport                                 |
-| `debug`                      | `boolean`                     | `false`  | Enable debug logging and visualizations                                       |
-| `containerClass`             | `string`                      | `''`     | Class for outer container                                                     |
-| `viewportClass`              | `string`                      | `''`     | Class for scrollable viewport                                                 |
-| `contentClass`               | `string`                      | `''`     | Class for content wrapper                                                     |
-| `itemsClass`                 | `string`                      | `''`     | Class for items container                                                     |
-| `testId`                     | `string`                      | `''`     | Base test id used in internal test hooks (useful for E2E/tests and debugging) |
-| `onLoadMore`                 | `() => void \| Promise<void>` | -        | Callback when more data is needed for infinite scroll                         |
-| `loadMoreThreshold`          | `number`                      | `20`     | Items from end to trigger `onLoadMore`                                        |
-| `hasMore`                    | `boolean`                     | `true`   | Set to `false` when all data has been loaded                                  |
+| Prop                         | Type                          | Default             | Description                                                                   |
+| ---------------------------- | ----------------------------- | ------------------- | ----------------------------------------------------------------------------- |
+| `items`                      | `T[]`                         | Required            | Array of items to render                                                      |
+| `defaultEstimatedItemHeight` | `number`                      | `40`                | Initial height estimate used until items are measured                         |
+| `bufferSize`                 | `number`                      | `20`                | Number of items rendered outside the viewport                                 |
+| `debug`                      | `boolean`                     | `false`             | Enable debug logging and visualizations                                       |
+| `containerClass`             | `string`                      | `''`                | Class for outer container                                                     |
+| `viewportClass`              | `string`                      | `''`                | Class for scrollable viewport                                                 |
+| `viewportLabel`              | `string`                      | `'Scrollable list'` | Accessible label for the focusable viewport region                            |
+| `contentClass`               | `string`                      | `''`                | Class for content wrapper                                                     |
+| `itemsClass`                 | `string`                      | `''`                | Class for items container                                                     |
+| `testId`                     | `string`                      | `''`                | Base test id used in internal test hooks (useful for E2E/tests and debugging) |
+| `onLoadMore`                 | `() => void \| Promise<void>` | -                   | Callback when more data is needed for infinite scroll                         |
+| `loadMoreThreshold`          | `number`                      | `20`                | Items from end to trigger `onLoadMore`                                        |
+| `hasMore`                    | `boolean`                     | `true`              | Set to `false` when all data has been loaded                                  |
 
 ## Programmatic Scrolling
 
@@ -239,18 +241,18 @@ This project uses [Trunk](https://trunk.io) for formatting and linting. Trunk ma
 
 Part of the [Humanspeak](https://humanspeak.com) family of runes-native Svelte 5 packages:
 
-| Package | Description |
-| --- | --- |
-| [@humanspeak/svelte-markdown](https://markdown.svelte.page) | Runtime markdown renderer for Svelte |
-| **[@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)** — _this package_ | Virtual scrolling for Svelte |
-| [@humanspeak/svelte-motion](https://motion.svelte.page) | Framer Motion for Svelte 5 |
-| [@humanspeak/svelte-headless-table](https://table.svelte.page) | Headless data tables for Svelte |
-| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page) | Diff comparison for Svelte |
-| [@humanspeak/svelte-purify](https://purify.svelte.page) | HTML sanitisation for Svelte |
-| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page) | Virtual chat viewport for Svelte 5 |
-| [@humanspeak/memory-cache](https://memory.svelte.page) | In-memory cache for TypeScript |
-| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page) | JSON tree viewer for Svelte 5 |
-| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page) | Scoped class props for Svelte |
+| Package                                                                                 | Description                          |
+| --------------------------------------------------------------------------------------- | ------------------------------------ |
+| [@humanspeak/svelte-markdown](https://markdown.svelte.page)                             | Runtime markdown renderer for Svelte |
+| **[@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)** — _this package_ | Virtual scrolling for Svelte         |
+| [@humanspeak/svelte-motion](https://motion.svelte.page)                                 | Framer Motion for Svelte 5           |
+| [@humanspeak/svelte-headless-table](https://table.svelte.page)                          | Headless data tables for Svelte      |
+| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page)                         | Diff comparison for Svelte           |
+| [@humanspeak/svelte-purify](https://purify.svelte.page)                                 | HTML sanitisation for Svelte         |
+| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page)                      | Virtual chat viewport for Svelte 5   |
+| [@humanspeak/memory-cache](https://memory.svelte.page)                                  | In-memory cache for TypeScript       |
+| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page)                       | JSON tree viewer for Svelte 5        |
+| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page)                           | Scoped class props for Svelte        |
 
 ## License
 

--- a/docs/src/lib/docsNav.ts
+++ b/docs/src/lib/docsNav.ts
@@ -1,4 +1,5 @@
 import type { Breadcrumb, NavSection } from '@humanspeak/docs-kit'
+import Accessibility from '@lucide/svelte/icons/accessibility'
 import ArrowUpDown from '@lucide/svelte/icons/arrow-up-down'
 import Book from '@lucide/svelte/icons/book'
 import Bug from '@lucide/svelte/icons/bug'
@@ -95,6 +96,7 @@ export const docsSections: NavSection[] = [
             { title: 'Variable Heights', href: '/docs/variable-heights', icon: ArrowUpDown },
             { title: 'Infinite Scroll', href: '/docs/infinite-scroll', icon: InfinityIcon },
             { title: 'Scroll Methods', href: '/docs/scroll-methods', icon: Crosshair },
+            { title: 'Keyboard & Accessibility', href: '/docs/accessibility', icon: Accessibility },
             { title: 'SSR Support', href: '/docs/ssr', icon: Server },
             { title: 'Debug Mode', href: '/docs/debug', icon: Bug },
             { title: 'Convex', href: '/docs/convex', icon: Database }

--- a/docs/src/lib/examples/AccessibilityExample.svelte
+++ b/docs/src/lib/examples/AccessibilityExample.svelte
@@ -6,24 +6,23 @@
         text: `Item ${i}`
     }))
 
+    const SCROLL_KEYS = new Set(['ArrowDown', 'ArrowUp', 'PageDown', 'PageUp', 'Home', 'End', ' '])
+
     let lastKey = $state<string | null>(null)
     let focused = $state(false)
 
     function describeKey(event: KeyboardEvent) {
-        // Capture-phase listener on the wrapper so the badge updates without
-        // interfering with the component's own handling.
-        const name = event.key === ' ' ? (event.shiftKey ? 'Shift+Space' : 'Space') : event.key
-        if (['ArrowDown', 'ArrowUp', 'PageDown', 'PageUp', 'Home', 'End', ' '].includes(event.key))
-            lastKey = name
+        if (!SCROLL_KEYS.has(event.key)) return
+        lastKey = event.key === ' ' ? (event.shiftKey ? 'Shift+Space' : 'Space') : event.key
     }
 </script>
 
 <div class="flex w-full grow flex-col gap-4 md:flex-row">
     <div
         class="border-border h-[300px] flex-1 rounded border md:h-auto"
-        onkeydowncapture={describeKey}
-        onfocusincapture={() => (focused = true)}
-        onfocusoutcapture={() => (focused = false)}
+        onkeydown={describeKey}
+        onfocusin={() => (focused = true)}
+        onfocusout={() => (focused = false)}
     >
         <VirtualList {items} viewportLabel="Keyboard demo list">
             {#snippet renderItem(item)}

--- a/docs/src/lib/examples/AccessibilityExample.svelte
+++ b/docs/src/lib/examples/AccessibilityExample.svelte
@@ -18,9 +18,9 @@
     }
 </script>
 
-<div class="flex w-full max-w-2xl flex-col gap-4 md:flex-row">
+<div class="flex w-full grow flex-col gap-4 md:flex-row">
     <div
-        class="border-border h-[300px] flex-1 rounded border"
+        class="border-border h-[300px] flex-1 rounded border md:h-auto"
         onkeydowncapture={describeKey}
         onfocusincapture={() => (focused = true)}
         onfocusoutcapture={() => (focused = false)}

--- a/docs/src/lib/examples/AccessibilityExample.svelte
+++ b/docs/src/lib/examples/AccessibilityExample.svelte
@@ -1,0 +1,73 @@
+<script lang="ts">
+    import VirtualList from '@humanspeak/svelte-virtual-list'
+
+    const items = Array.from({ length: 1000 }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    }))
+
+    let lastKey = $state<string | null>(null)
+    let focused = $state(false)
+
+    function describeKey(event: KeyboardEvent) {
+        // Capture-phase listener on the wrapper so the badge updates without
+        // interfering with the component's own handling.
+        const name = event.key === ' ' ? (event.shiftKey ? 'Shift+Space' : 'Space') : event.key
+        if (['ArrowDown', 'ArrowUp', 'PageDown', 'PageUp', 'Home', 'End', ' '].includes(event.key))
+            lastKey = name
+    }
+</script>
+
+<div class="flex w-full max-w-2xl flex-col gap-4 md:flex-row">
+    <div
+        class="border-border h-[300px] flex-1 rounded border"
+        onkeydowncapture={describeKey}
+        onfocusincapture={() => (focused = true)}
+        onfocusoutcapture={() => (focused = false)}
+    >
+        <VirtualList {items} viewportLabel="Keyboard demo list">
+            {#snippet renderItem(item)}
+                <div class="border-border border-b px-4 py-3">
+                    {item.text}
+                </div>
+            {/snippet}
+        </VirtualList>
+    </div>
+    <div class="border-border bg-muted/50 flex-1 rounded border p-4">
+        <h3 class="mb-3 text-sm font-medium">Try it with your keyboard</h3>
+        <p class="text-muted-foreground mb-3 text-xs">
+            Press <kbd class="rounded border px-1">Tab</kbd> until the list has a focus ring, then use
+            the scroll keys.
+        </p>
+        <div class="space-y-2 text-xs">
+            <div class="flex justify-between">
+                <span class="text-muted-foreground">List focused:</span>
+                <span class="font-mono">{focused ? 'yes' : 'no'}</span>
+            </div>
+            <div class="flex justify-between">
+                <span class="text-muted-foreground">Last scroll key:</span>
+                <span class="font-mono">{lastKey ?? '—'}</span>
+            </div>
+        </div>
+        <table class="mt-4 w-full text-xs">
+            <tbody>
+                <tr>
+                    <td class="text-muted-foreground py-1">↑ / ↓</td>
+                    <td class="text-right">one line</td>
+                </tr>
+                <tr>
+                    <td class="text-muted-foreground py-1">PageUp / PageDown</td>
+                    <td class="text-right">one page</td>
+                </tr>
+                <tr>
+                    <td class="text-muted-foreground py-1">Space / Shift+Space</td>
+                    <td class="text-right">one page</td>
+                </tr>
+                <tr>
+                    <td class="text-muted-foreground py-1">Home / End</td>
+                    <td class="text-right">top / bottom</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</div>

--- a/docs/src/routes/docs/accessibility/+page.svx
+++ b/docs/src/routes/docs/accessibility/+page.svx
@@ -83,10 +83,10 @@ The component only claims a key when the viewport itself is focused. If focus is
 
 The viewport draws an inset focus ring (`outline-offset: -2px`, `currentColor`) on `:focus-visible`. It is inset on purpose: the viewport fills a container with `overflow: hidden`, which would clip a default outside outline away entirely — keyboard users would see nothing.
 
-To restyle it, target your `viewportClass` — note that passing `viewportClass` replaces the component's default class, so bring your own focus style with it:
+The ring is applied unconditionally — passing a custom `viewportClass` does not remove it — and it is defined at low specificity so your stylesheet can restyle it:
 
 ```css
-.my-viewport:focus-visible {
+div.my-viewport:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: -2px; /* keep it inset — outside outlines get clipped */
 }

--- a/docs/src/routes/docs/accessibility/+page.svx
+++ b/docs/src/routes/docs/accessibility/+page.svx
@@ -81,11 +81,13 @@ The component only claims a key when the viewport itself is focused. If focus is
 
 ## Focus styling
 
-The viewport keeps the browser's default `:focus-visible` outline, so keyboard focus is visible without any configuration. To restyle it, target your `viewportClass`:
+The viewport draws an inset focus ring (`outline-offset: -2px`, `currentColor`) on `:focus-visible`. It is inset on purpose: the viewport fills a container with `overflow: hidden`, which would clip a default outside outline away entirely — keyboard users would see nothing.
+
+To restyle it, target your `viewportClass` — note that passing `viewportClass` replaces the component's default class, so bring your own focus style with it:
 
 ```css
 .my-viewport:focus-visible {
     outline: 2px solid var(--accent);
-    outline-offset: -2px;
+    outline-offset: -2px; /* keep it inset — outside outlines get clipped */
 }
 ```

--- a/docs/src/routes/docs/accessibility/+page.svx
+++ b/docs/src/routes/docs/accessibility/+page.svx
@@ -1,0 +1,91 @@
+---
+title: 'Keyboard & Accessibility'
+description: 'Keyboard navigation and assistive-technology support in Svelte Virtual List'
+---
+
+<script>
+  import Example from '$lib/components/general/Example.svelte'
+  import AccessibilityExample from '$lib/examples/AccessibilityExample.svelte'
+  import { getSeoContext } from '$lib/components/contexts/Seo/Seo.context'
+
+  const seo = getSeoContext()
+  if (seo) {
+    seo.title = 'Keyboard & Accessibility | Docs | Svelte Virtual List'
+    seo.description = 'Keyboard navigation and assistive-technology support in Svelte Virtual List'
+    seo.ogTitle = 'Keyboard & Accessibility'
+    seo.ogTagline = 'Focusable, labeled, and fully keyboard-operable.'
+    seo.ogFeatures = ['Focusable Region', 'Standard Scroll Keys', 'Configurable Label', 'Cross-Engine']
+    seo.ogSlug = 'docs-accessibility'
+  }
+</script>
+
+# Keyboard & Accessibility
+
+The scroll viewport is a focusable, labeled region that handles the standard scroll keys itself — so keyboard users get the same experience in every browser, and assistive technology announces the list meaningfully.
+
+<Example isSmall file="AccessibilityExample.svelte" title="Keyboard navigation">
+  <AccessibilityExample />
+</Example>
+
+## Why the component owns this
+
+A bare `overflow-y: scroll` element is not reliably keyboard-operable: Chrome and Firefox make scrollable elements focusable and scroll them with the keyboard, but Safari does not focus them at all — a keyboard user simply cannot reach the list. Screen readers also announce an unlabeled scrollable group with no hint of what it contains.
+
+Svelte Virtual List closes both gaps at the component level:
+
+- The viewport renders with `role="region"`, `tabindex="0"`, and an `aria-label`, making it a Tab stop and a named landmark in every engine.
+- The component handles the scroll keys itself instead of relying on engine-dependent native behavior.
+
+## Key bindings
+
+With the viewport focused:
+
+| Key                          | Action                                            |
+| ---------------------------- | ------------------------------------------------- |
+| `ArrowDown` / `ArrowUp`      | Scroll one line (40px)                            |
+| `PageDown` / `PageUp`        | Scroll one page (viewport height minus one line)  |
+| `Space` / `Shift+Space`      | Scroll one page down / up                         |
+| `Home` / `End`               | Jump to the top / bottom of the list              |
+
+Handled keys call `preventDefault()`, so `Space` scrolls the list instead of paging the document. Keys with `Ctrl`, `Meta`, or `Alt` modifiers pass through untouched — browser shortcuts keep working.
+
+## Labeling the region
+
+Set `viewportLabel` to describe what the list contains. Screen readers announce it when the user reaches the region.
+
+```svelte
+<VirtualList {items} viewportLabel="Search results">
+    {#snippet renderItem(item)}
+        <div>{item.text}</div>
+    {/snippet}
+</VirtualList>
+```
+
+The default label is `'Scrollable list'` — fine for a demo, but a real application should say what the list actually holds ("Order history", "Chat messages", "Search results").
+
+## Interactive content inside items
+
+The component only claims a key when the viewport itself is focused. If focus is on a button, link, or input rendered inside an item, keys keep their native behavior — `Space` still activates the button, arrows still move the text cursor. Nothing is hijacked.
+
+```svelte
+<VirtualList {items} viewportLabel="Inbox">
+    {#snippet renderItem(item)}
+        <div>
+            {item.subject}
+            <!-- Space activates this button; the list does not scroll -->
+            <button onclick={() => archive(item)}>Archive</button>
+        </div>
+    {/snippet}
+</VirtualList>
+```
+
+## Focus styling
+
+The viewport keeps the browser's default `:focus-visible` outline, so keyboard focus is visible without any configuration. To restyle it, target your `viewportClass`:
+
+```css
+.my-viewport:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+}
+```

--- a/docs/src/routes/docs/api/props/+page.svx
+++ b/docs/src/routes/docs/api/props/+page.svx
@@ -113,6 +113,14 @@ CSS class for the scrollable viewport element.
 viewportClass?: string
 ```
 
+### viewportLabel
+
+Accessible label announced for the scrollable viewport. The viewport renders as a focusable `role="region"`, so keyboard users can Tab to it and operate it with the standard scroll keys (arrows, PageUp/PageDown, Space, Shift+Space, Home, End).
+
+```typescript
+viewportLabel?: string // default: 'Scrollable list'
+```
+
 ### contentClass
 
 CSS class for the content wrapper element.

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -163,7 +163,11 @@
         updateHeightAndScroll as utilsUpdateHeightAndScroll
     } from '$lib/utils/virtualList.js'
     import { createDebugInfo, shouldShowDebugInfo } from '$lib/utils/virtualListDebug.js'
-    import { calculateScrollTarget } from '$lib/utils/scrollCalculation.js'
+    import {
+        calculateKeyboardScrollTarget,
+        calculateScrollTarget,
+        isKeyboardScrollKey
+    } from '$lib/utils/scrollCalculation.js'
     import { waitForScrollEnd } from '$lib/utils/scrollEnd.js'
     import { createAdvancedThrottledCallback } from '$lib/utils/throttle.js'
     import { ReactiveListManager } from '$lib/index.js'
@@ -280,56 +284,38 @@
         heightManager.scrollTop = scrollValue
     }
 
-    // Per-keypress scroll distance for arrow keys, matching typical browser
-    // native line scrolling.
-    const LINE_SCROLL_PX = 40
-
     /**
      * Keyboard scrolling for the focusable viewport (issue #414). Native
      * keyboard scrolling of an overflow div is engine-dependent (Safari
      * does not even focus it), so the component owns the standard scroll
-     * keys itself: arrows move a line, PageUp/PageDown and Space/Shift+Space
-     * move a page (viewport height minus one line of overlap), Home/End jump
-     * to the edges. Only fires when the viewport itself is focused — keys
-     * pressed inside interactive item content (buttons, inputs) keep their
-     * native behavior.
+     * keys itself — the key→target math lives in
+     * {@link calculateKeyboardScrollTarget}. Only fires when the viewport
+     * itself is focused — keys pressed inside interactive item content
+     * (buttons, inputs) keep their native behavior.
      */
     const handleViewportKeydown = (event: KeyboardEvent) => {
         if (event.target !== event.currentTarget) return
         if (event.ctrlKey || event.metaKey || event.altKey) return
         if (!heightManager.viewportElement) return
+        // Gate BEFORE the layout reads below: unhandled keys must not force
+        // a reflow on every press.
+        if (!isKeyboardScrollKey(event.key)) return
 
         const viewport = heightManager.viewport
-        const maxScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
-        const page = Math.max(viewport.clientHeight - LINE_SCROLL_PX, LINE_SCROLL_PX)
-
-        let target: number | null = null
-        switch (event.key) {
-            case 'ArrowDown':
-                target = viewport.scrollTop + LINE_SCROLL_PX
-                break
-            case 'ArrowUp':
-                target = viewport.scrollTop - LINE_SCROLL_PX
-                break
-            case 'PageDown':
-                target = viewport.scrollTop + page
-                break
-            case 'PageUp':
-                target = viewport.scrollTop - page
-                break
-            case ' ':
-                target = viewport.scrollTop + (event.shiftKey ? -page : page)
-                break
-            case 'Home':
-                target = 0
-                break
-            case 'End':
-                target = maxScrollTop
-                break
-        }
+        const target = calculateKeyboardScrollTarget({
+            key: event.key,
+            shiftKey: event.shiftKey,
+            scrollTop: viewport.scrollTop,
+            clientHeight: viewport.clientHeight,
+            scrollHeight: viewport.scrollHeight
+        })
         if (target === null) return
         event.preventDefault()
-        syncScrollTop(clampValue(target, 0, maxScrollTop), true)
+        // User input supersedes a programmatic scroll() the same way a newer
+        // scroll() call would — abort it so its completion machinery cannot
+        // re-assert a stale target over the keyboard position.
+        scrollAbortController?.abort()
+        syncScrollTop(target, true)
     }
 
     // Counts in-flight programmatic scroll() waits. Anchor preservation must
@@ -1113,6 +1099,9 @@
 
             // Update scrollTop state in next frame to avoid synchronous re-renders
             requestAnimationFrame(() => {
+                // Superseded (newer scroll() or keyboard input): don't clobber
+                // the newer position with this scroll's stale target.
+                if (signal.aborted) return
                 heightManager.scrollTop = scrollTarget
                 if (INTERNAL_DEBUG && heightManager.viewportElement) {
                     const domMax = Math.max(
@@ -1247,8 +1236,13 @@
 
     /* Keyboard-focus ring, drawn INSIDE the box: the viewport fills a
        container with overflow: hidden, so the default outside outline is
-       clipped away entirely and keyboard users get no focus indicator. */
-    .virtual-list-viewport:focus-visible {
+       clipped away entirely and keyboard users get no focus indicator.
+
+       Keyed off the always-present role/tabindex attributes — NOT the
+       .virtual-list-viewport class, which a consumer's viewportClass
+       replaces (the ring must not be opt-out-by-accident). :where() keeps
+       specificity low so consumer stylesheets can still restyle it. */
+    :where(div[role='region'][tabindex='0']):focus-visible {
         outline: 2px solid currentColor;
         outline-offset: -2px;
     }

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -192,6 +192,7 @@
         renderItem, // Function to render each item
         containerClass, // Custom class for the container element
         viewportClass, // Custom class for the viewport element
+        viewportLabel = 'Scrollable list', // Accessible label for the focusable viewport region
         contentClass, // Custom class for the content wrapper
         itemsClass, // Custom class for the items wrapper
         debugFunction, // Custom debug logging function
@@ -277,6 +278,58 @@
         const scrollValue = round ? Math.round(value) : value
         heightManager.viewport.scrollTop = scrollValue
         heightManager.scrollTop = scrollValue
+    }
+
+    // Per-keypress scroll distance for arrow keys, matching typical browser
+    // native line scrolling.
+    const LINE_SCROLL_PX = 40
+
+    /**
+     * Keyboard scrolling for the focusable viewport (issue #414). Native
+     * keyboard scrolling of an overflow div is engine-dependent (Safari
+     * does not even focus it), so the component owns the standard scroll
+     * keys itself: arrows move a line, PageUp/PageDown and Space/Shift+Space
+     * move a page (viewport height minus one line of overlap), Home/End jump
+     * to the edges. Only fires when the viewport itself is focused — keys
+     * pressed inside interactive item content (buttons, inputs) keep their
+     * native behavior.
+     */
+    const handleViewportKeydown = (event: KeyboardEvent) => {
+        if (event.target !== event.currentTarget) return
+        if (event.ctrlKey || event.metaKey || event.altKey) return
+        if (!heightManager.viewportElement) return
+
+        const viewport = heightManager.viewport
+        const maxScrollTop = Math.max(0, viewport.scrollHeight - viewport.clientHeight)
+        const page = Math.max(viewport.clientHeight - LINE_SCROLL_PX, LINE_SCROLL_PX)
+
+        let target: number | null = null
+        switch (event.key) {
+            case 'ArrowDown':
+                target = viewport.scrollTop + LINE_SCROLL_PX
+                break
+            case 'ArrowUp':
+                target = viewport.scrollTop - LINE_SCROLL_PX
+                break
+            case 'PageDown':
+                target = viewport.scrollTop + page
+                break
+            case 'PageUp':
+                target = viewport.scrollTop - page
+                break
+            case ' ':
+                target = viewport.scrollTop + (event.shiftKey ? -page : page)
+                break
+            case 'Home':
+                target = 0
+                break
+            case 'End':
+                target = maxScrollTop
+                break
+        }
+        if (target === null) return
+        event.preventDefault()
+        syncScrollTop(clampValue(target, 0, maxScrollTop), true)
     }
 
     // Counts in-flight programmatic scroll() waits. Anchor preservation must
@@ -1121,13 +1174,18 @@
     class={containerClass ?? 'virtual-list-container'}
     bind:this={heightManager.containerElement}
 >
-    <!-- Viewport handles scrolling -->
+    <!-- Viewport handles scrolling. Focusable labeled region so keyboard
+         users can operate the scroll area directly (issue #414). -->
     <div
         id="virtual-list-viewport"
         {...testId ? { 'data-testid': `${testId}-viewport` } : {}}
         class={viewportClass ?? 'virtual-list-viewport'}
         bind:this={heightManager.viewportElement}
+        role="region"
+        aria-label={viewportLabel}
+        tabindex="0"
         onscroll={handleScroll}
+        onkeydown={handleViewportKeydown}
         style:overflow-anchor="none"
     >
         <!-- Content provides full scrollable height -->

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -1245,6 +1245,14 @@
         -webkit-overflow-scrolling: touch;
     }
 
+    /* Keyboard-focus ring, drawn INSIDE the box: the viewport fills a
+       container with overflow: hidden, so the default outside outline is
+       clipped away entirely and keyboard users get no focus indicator. */
+    .virtual-list-viewport:focus-visible {
+        outline: 2px solid currentColor;
+        outline-offset: -2px;
+    }
+
     /* Content wrapper maintains full scrollable height */
     .virtual-list-content {
         position: relative;

--- a/src/lib/SvelteVirtualList.test.ts
+++ b/src/lib/SvelteVirtualList.test.ts
@@ -486,5 +486,40 @@ describe('SvelteVirtualList Component', () => {
             expect(screen.getByTestId('my-list-content')).toBeInTheDocument()
             expect(screen.getByTestId('my-list-items')).toBeInTheDocument()
         })
+
+        test('exposes the viewport as a focusable labeled region', async () => {
+            const items = createMockItems(5)
+
+            render(TestWrapper, {
+                props: {
+                    testId: 'a11y-list',
+                    items
+                }
+            })
+
+            await vi.runAllTimersAsync()
+
+            const viewport = screen.getByTestId('a11y-list-viewport')
+            expect(viewport.getAttribute('role')).toBe('region')
+            expect(viewport.getAttribute('aria-label')).toBe('Scrollable list')
+            expect(viewport.getAttribute('tabindex')).toBe('0')
+        })
+
+        test('applies a custom viewportLabel', async () => {
+            const items = createMockItems(5)
+
+            render(TestWrapper, {
+                props: {
+                    testId: 'labeled-list',
+                    items,
+                    viewportLabel: 'Search results'
+                }
+            })
+
+            await vi.runAllTimersAsync()
+
+            const viewport = screen.getByTestId('labeled-list-viewport')
+            expect(viewport.getAttribute('aria-label')).toBe('Search results')
+        })
     })
 })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,6 +55,12 @@ export type SvelteVirtualListProps<TItem = any> = {
      */
     viewportClass?: string
     /**
+     * Accessible label announced for the scrollable viewport (rendered as a
+     * focusable `role="region"` so keyboard users can operate it directly).
+     * @default 'Scrollable list'
+     */
+    viewportLabel?: string
+    /**
      * Callback when more data is needed. Supports sync and async functions.
      * Called when the user scrolls near the end of the list (based on loadMoreThreshold).
      */

--- a/src/lib/utils/scrollCalculation.test.ts
+++ b/src/lib/utils/scrollCalculation.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { ScrollTargetParams } from './scrollCalculation.js'
 import {
+    KEYBOARD_LINE_SCROLL_PX,
     alignToEdge,
     alignVisibleToNearestEdge,
-    calculateScrollTarget
+    calculateKeyboardScrollTarget,
+    calculateScrollTarget,
+    isKeyboardScrollKey
 } from './scrollCalculation.js'
 
 describe('alignToEdge', () => {
@@ -478,5 +481,97 @@ describe('calculateScrollTarget', () => {
             expect(typeof result).toBe('number')
             expect(result).toBeGreaterThanOrEqual(0)
         })
+    })
+})
+
+describe('isKeyboardScrollKey', () => {
+    it('accepts every standard scroll key', () => {
+        for (const key of ['ArrowDown', 'ArrowUp', 'PageDown', 'PageUp', ' ', 'Home', 'End']) {
+            expect(isKeyboardScrollKey(key)).toBe(true)
+        }
+    })
+
+    it('rejects non-scroll keys', () => {
+        for (const key of ['Tab', 'Escape', 'Enter', 'a', 'ArrowLeft', 'ArrowRight']) {
+            expect(isKeyboardScrollKey(key)).toBe(false)
+        }
+    })
+})
+
+describe('calculateKeyboardScrollTarget', () => {
+    // 400px viewport over 8000px of content, resting mid-list
+    const base = { shiftKey: false, scrollTop: 2000, clientHeight: 400, scrollHeight: 8000 }
+    const maxScrollTop = base.scrollHeight - base.clientHeight
+    const page = base.clientHeight - KEYBOARD_LINE_SCROLL_PX
+
+    it('moves one line on arrows', () => {
+        expect(calculateKeyboardScrollTarget({ ...base, key: 'ArrowDown' })).toBe(
+            base.scrollTop + KEYBOARD_LINE_SCROLL_PX
+        )
+        expect(calculateKeyboardScrollTarget({ ...base, key: 'ArrowUp' })).toBe(
+            base.scrollTop - KEYBOARD_LINE_SCROLL_PX
+        )
+    })
+
+    it('moves one page with a line of overlap on page keys', () => {
+        expect(calculateKeyboardScrollTarget({ ...base, key: 'PageDown' })).toBe(
+            base.scrollTop + page
+        )
+        expect(calculateKeyboardScrollTarget({ ...base, key: 'PageUp' })).toBe(
+            base.scrollTop - page
+        )
+    })
+
+    it('pages down on Space and up on Shift+Space', () => {
+        expect(calculateKeyboardScrollTarget({ ...base, key: ' ' })).toBe(base.scrollTop + page)
+        expect(calculateKeyboardScrollTarget({ ...base, key: ' ', shiftKey: true })).toBe(
+            base.scrollTop - page
+        )
+    })
+
+    it('jumps to the edges on Home and End', () => {
+        expect(calculateKeyboardScrollTarget({ ...base, key: 'Home' })).toBe(0)
+        expect(calculateKeyboardScrollTarget({ ...base, key: 'End' })).toBe(maxScrollTop)
+    })
+
+    it('clamps at both edges', () => {
+        expect(calculateKeyboardScrollTarget({ ...base, scrollTop: 10, key: 'ArrowUp' })).toBe(0)
+        expect(
+            calculateKeyboardScrollTarget({
+                ...base,
+                scrollTop: maxScrollTop - 10,
+                key: 'PageDown'
+            })
+        ).toBe(maxScrollTop)
+    })
+
+    it('keeps a minimum one-line page in tiny viewports', () => {
+        // clientHeight smaller than one line: page distance floors at one line
+        expect(
+            calculateKeyboardScrollTarget({
+                key: 'PageDown',
+                shiftKey: false,
+                scrollTop: 100,
+                clientHeight: 20,
+                scrollHeight: 8000
+            })
+        ).toBe(100 + KEYBOARD_LINE_SCROLL_PX)
+    })
+
+    it('returns null for keys the viewport does not handle', () => {
+        expect(calculateKeyboardScrollTarget({ ...base, key: 'Tab' })).toBeNull()
+        expect(calculateKeyboardScrollTarget({ ...base, key: 'ArrowLeft' })).toBeNull()
+    })
+
+    it('never returns a negative target when content fits the viewport', () => {
+        expect(
+            calculateKeyboardScrollTarget({
+                key: 'End',
+                shiftKey: false,
+                scrollTop: 0,
+                clientHeight: 400,
+                scrollHeight: 200
+            })
+        ).toBe(0)
     })
 })

--- a/src/lib/utils/scrollCalculation.ts
+++ b/src/lib/utils/scrollCalculation.ts
@@ -82,6 +82,81 @@ export const alignVisibleToNearestEdge = (
 /**
  * Parameters for calculating scroll target position
  */
+/**
+ * Per-keypress scroll distance for arrow keys, matching the fixed ~40px line
+ * step browsers use for native keyboard scrolling. Deliberately NOT derived
+ * from item heights: native scrolling does not know about rows either, and a
+ * fixed step keeps arrow behavior predictable across lists.
+ */
+export const KEYBOARD_LINE_SCROLL_PX = 40
+
+const KEYBOARD_SCROLL_KEYS = new Set([
+    'ArrowDown',
+    'ArrowUp',
+    'PageDown',
+    'PageUp',
+    ' ',
+    'Home',
+    'End'
+])
+
+/**
+ * Whether a KeyboardEvent.key is one of the standard scroll keys the
+ * viewport handles. Callers should gate on this BEFORE reading viewport
+ * layout (scrollTop/clientHeight/scrollHeight) so unhandled keys — the
+ * common case while typing — never force a reflow.
+ */
+export const isKeyboardScrollKey = (key: string): boolean => KEYBOARD_SCROLL_KEYS.has(key)
+
+export interface KeyboardScrollParams {
+    /** KeyboardEvent.key */
+    key: string
+    /** KeyboardEvent.shiftKey (Shift+Space pages up) */
+    shiftKey: boolean
+    scrollTop: number
+    clientHeight: number
+    scrollHeight: number
+}
+
+/**
+ * Pure key→scrollTop mapping for viewport keyboard scrolling (issue #414):
+ * arrows move one line ({@link KEYBOARD_LINE_SCROLL_PX}), PageUp/PageDown and
+ * Space/Shift+Space move one page (viewport height minus one line of
+ * overlap), Home/End jump to the edges. Returns the clamped target, or null
+ * for keys the viewport does not handle.
+ */
+export const calculateKeyboardScrollTarget = (params: KeyboardScrollParams): number | null => {
+    const { key, shiftKey, scrollTop, clientHeight, scrollHeight } = params
+    const maxScrollTop = Math.max(0, scrollHeight - clientHeight)
+    const page = Math.max(clientHeight - KEYBOARD_LINE_SCROLL_PX, KEYBOARD_LINE_SCROLL_PX)
+
+    let target: number | null = null
+    switch (key) {
+        case 'ArrowDown':
+            target = scrollTop + KEYBOARD_LINE_SCROLL_PX
+            break
+        case 'ArrowUp':
+            target = scrollTop - KEYBOARD_LINE_SCROLL_PX
+            break
+        case 'PageDown':
+            target = scrollTop + page
+            break
+        case 'PageUp':
+            target = scrollTop - page
+            break
+        case ' ':
+            target = scrollTop + (shiftKey ? -page : page)
+            break
+        case 'Home':
+            target = 0
+            break
+        case 'End':
+            target = maxScrollTop
+            break
+    }
+    return target === null ? null : clampValue(target, 0, maxScrollTop)
+}
+
 export interface ScrollTargetParams {
     align: SvelteVirtualListScrollAlign
     targetIndex: number

--- a/src/routes/tests/issues/issue-414/+page.svelte
+++ b/src/routes/tests/issues/issue-414/+page.svelte
@@ -1,0 +1,354 @@
+<script lang="ts">
+    import { onMount } from 'svelte'
+    import SvelteVirtualList from '$lib/index.js'
+
+    type Item = {
+        id: number
+        text: string
+    }
+
+    // Fixed-height items: keyboard support is about focus, semantics, and
+    // scroll mechanics — measurement is not the variable here.
+    const ITEM_COUNT = 200
+    const ITEM_HEIGHT_PX = 40
+
+    const items: Item[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    }))
+
+    // Every scroll key the viewport must handle itself. Synthetic
+    // KeyboardEvents are untrusted, so browsers never natively scroll from
+    // them — each probe below measures the COMPONENT's own keydown handler,
+    // not engine-dependent native behavior. That is exactly the point:
+    // native keyboard scrolling of a bare overflow div is inconsistent
+    // across engines (Safari does not even focus it), so the component must
+    // own the keys.
+    type KeyProbe = {
+        stat: string
+        key: string
+        shiftKey?: boolean
+        /** 'down' | 'up' expect a relative move; 'home' | 'end' expect an edge. */
+        expect: 'down' | 'up' | 'home' | 'end'
+    }
+    const KEY_PROBES: KeyProbe[] = [
+        { stat: 'arrowDown', key: 'ArrowDown', expect: 'down' },
+        { stat: 'arrowUp', key: 'ArrowUp', expect: 'up' },
+        { stat: 'pageDown', key: 'PageDown', expect: 'down' },
+        { stat: 'pageUp', key: 'PageUp', expect: 'up' },
+        { stat: 'space', key: ' ', expect: 'down' },
+        { stat: 'shiftSpace', key: ' ', shiftKey: true, expect: 'up' },
+        { stat: 'home', key: 'Home', expect: 'home' },
+        { stat: 'end', key: 'End', expect: 'end' }
+    ]
+
+    let focusable = $state<boolean | null>(null)
+    let role = $state<string | null>(null)
+    let ariaLabel = $state<string | null>(null)
+    let keyResults = $state<Record<string, boolean> | null>(null)
+    let running = $state(false)
+    let probed = $state(false)
+
+    const labeled = $derived(role === 'region' && !!ariaLabel)
+    const keysPass = $derived(keyResults !== null && Object.values(keyResults).every(Boolean))
+    const keysLine = $derived(
+        keyResults === null
+            ? null
+            : KEY_PROBES.map((probe) => `${probe.stat}=${keyResults?.[probe.stat] ? 1 : 0}`).join(
+                  ' '
+              )
+    )
+
+    const getViewport = (): HTMLElement | null =>
+        document.querySelector('[data-testid="issue-414-list-viewport"]')
+
+    const nextFrame = () => new Promise<void>((r) => requestAnimationFrame(() => r()))
+
+    /** Wait until scrollTop has been stable for a few frames (handles both
+     *  instant and smooth scrolling), bounded so a dead key resolves fast. */
+    const settleScroll = async (viewport: HTMLElement, maxMs = 800) => {
+        const start = performance.now()
+        let last = viewport.scrollTop
+        let stableFrames = 0
+        while (performance.now() - start < maxMs) {
+            await nextFrame()
+            if (viewport.scrollTop === last) {
+                stableFrames++
+                if (stableFrames >= 3) return
+            } else {
+                stableFrames = 0
+                last = viewport.scrollTop
+            }
+        }
+    }
+
+    const runProbes = async () => {
+        const viewport = getViewport()
+        if (!viewport || running) return
+        running = true
+        keyResults = null
+
+        // Semantics: what assistive tech sees.
+        role = viewport.getAttribute('role')
+        ariaLabel = viewport.getAttribute('aria-label')
+
+        // Focusability: keyboard users must be able to land on the region.
+        viewport.focus()
+        focusable = document.activeElement === viewport
+
+        // Key matrix, each probe from a mid-list resting point so both
+        // directions have room to move.
+        const midScrollTop = Math.floor((viewport.scrollHeight - viewport.clientHeight) / 2)
+        const maxScrollTop = viewport.scrollHeight - viewport.clientHeight
+        const results: Record<string, boolean> = {}
+
+        for (const probe of KEY_PROBES) {
+            viewport.scrollTop = midScrollTop
+            await nextFrame()
+            await nextFrame()
+            viewport.focus()
+
+            const before = viewport.scrollTop
+            viewport.dispatchEvent(
+                new KeyboardEvent('keydown', {
+                    key: probe.key,
+                    shiftKey: probe.shiftKey ?? false,
+                    bubbles: true,
+                    cancelable: true
+                })
+            )
+            await settleScroll(viewport)
+            const after = viewport.scrollTop
+
+            switch (probe.expect) {
+                case 'down':
+                    results[probe.stat] = after > before + 1
+                    break
+                case 'up':
+                    results[probe.stat] = after < before - 1
+                    break
+                case 'home':
+                    results[probe.stat] = after <= 1
+                    break
+                case 'end':
+                    results[probe.stat] = after >= maxScrollTop - 2
+                    break
+            }
+        }
+
+        keyResults = results
+        running = false
+        probed = true
+    }
+
+    onMount(() => {
+        const timer = setTimeout(runProbes, 500)
+        return () => clearTimeout(timer)
+    })
+</script>
+
+<div class="page">
+    <h1>Issue #414 — keyboard accessibility for the scroll viewport</h1>
+
+    <div class="description">
+        <p>
+            <strong>What:</strong> the viewport is a bare <code>overflow-y: scroll</code> div.
+            Keyboard users can only operate it where the browser happens to make scrollable divs
+            focusable (Chrome and Firefox do, Safari does not), and assistive tech announces an
+            unlabeled group. The component should expose a labeled
+            <code>role="region"</code>, be focusable, and handle the standard scroll keys itself.
+        </p>
+        <p>
+            <strong>How it's measured:</strong> the probes check the rendered attributes, call
+            <code>focus()</code> and verify the viewport actually receives focus, then dispatch a
+            synthetic <code>keydown</code> per scroll key from a mid-list position and watch
+            <code>scrollTop</code>. Synthetic keys are untrusted so the browser never natively
+            scrolls from them — every green below is the component's own handler, deterministic
+            across engines.
+        </p>
+    </div>
+
+    <div class="stats" data-testid="issue-414-stats">
+        <div class="stat" class:pass={focusable === true} class:fail={focusable === false}>
+            <span class="light">{focusable === null ? '…' : focusable ? '✓' : '✗'}</span>
+            <span class="label">viewport is focusable</span>
+            <span class="value" data-testid="stat-focusable">
+                {focusable === null ? '—' : focusable ? 'yes' : 'no'}
+            </span>
+            <span class="expected"
+                >focus() must land on the viewport (tab target for keyboard users)</span
+            >
+        </div>
+
+        <div class="stat" class:pass={labeled} class:fail={probed && !labeled}>
+            <span class="light">{!probed && !labeled ? '…' : labeled ? '✓' : '✗'}</span>
+            <span class="label">labeled region for assistive tech</span>
+            <span class="value" data-testid="stat-labeled">
+                role={role ?? 'none'} label={ariaLabel ? 'yes' : 'none'}
+            </span>
+            <span class="expected">role="region" with a configurable aria-label</span>
+        </div>
+
+        <div class="stat" class:pass={keysPass} class:fail={keyResults !== null && !keysPass}>
+            <span class="light"
+                >{keyResults === null ? (running ? '⟳' : '…') : keysPass ? '✓' : '✗'}</span
+            >
+            <span class="label">scroll keys handled</span>
+            <span class="value" data-testid="stat-keys">
+                {#if keysLine !== null}
+                    {keysLine}
+                {:else if running}
+                    running…
+                {:else}
+                    —
+                {/if}
+            </span>
+            <span class="expected">
+                ArrowUp/Down, PageUp/Down, Space, Shift+Space, Home, End must all move the viewport
+            </span>
+        </div>
+
+        <button class="remeasure" onclick={runProbes} disabled={running}>
+            {running ? 'probing…' : 'Re-run probes'}
+        </button>
+    </div>
+
+    <div class="test-container" style="height: 400px;">
+        <SvelteVirtualList
+            defaultEstimatedItemHeight={ITEM_HEIGHT_PX}
+            {items}
+            testId="issue-414-list"
+        >
+            {#snippet renderItem(item)}
+                <div class="fixed-item" style="height: {ITEM_HEIGHT_PX}px;">
+                    {item.text}
+                </div>
+            {/snippet}
+        </SvelteVirtualList>
+    </div>
+</div>
+
+<style>
+    .page {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 16px;
+        font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
+    }
+
+    h1 {
+        font-size: 18px;
+        margin: 0 0 12px;
+    }
+
+    .description {
+        font-size: 13px;
+        line-height: 1.5;
+        color: #333;
+        background: #fafafa;
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 4px 14px;
+        margin-bottom: 12px;
+    }
+
+    .description code {
+        background: #eef2f7;
+        padding: 1px 4px;
+        border-radius: 3px;
+    }
+
+    .stats {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 12px;
+        font-size: 13px;
+    }
+
+    .stat {
+        display: grid;
+        grid-template-columns: 22px 210px minmax(120px, auto) 1fr;
+        gap: 8px;
+        align-items: baseline;
+        padding: 6px 10px;
+        border-radius: 6px;
+        border: 1px solid #e5e5e5;
+        background: #f6f6f6;
+    }
+
+    .stat.pass {
+        background: #e9f7ee;
+        border-color: #b7e2c4;
+    }
+
+    .stat.fail {
+        background: #fdeaea;
+        border-color: #f2b8b8;
+    }
+
+    .light {
+        font-weight: 700;
+    }
+
+    .stat.pass .light {
+        color: #1a7f37;
+    }
+
+    .stat.fail .light {
+        color: #c62828;
+    }
+
+    .label {
+        font-weight: 600;
+    }
+
+    .value {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+    }
+
+    .stat.pass .value {
+        color: #1a7f37;
+    }
+
+    .stat.fail .value {
+        color: #c62828;
+    }
+
+    .expected {
+        color: #777;
+        font-size: 12px;
+    }
+
+    .remeasure {
+        align-self: flex-start;
+        margin-top: 4px;
+        padding: 6px 14px;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 13px;
+    }
+
+    .remeasure:disabled {
+        opacity: 0.6;
+        cursor: wait;
+    }
+
+    .test-container {
+        width: 100%;
+        border: 1px solid #eee;
+    }
+
+    .fixed-item {
+        box-sizing: border-box;
+        padding: 8px 12px;
+        border-bottom: 1px solid #eee;
+        font-size: 14px;
+    }
+</style>

--- a/src/routes/tests/issues/issue-414/+page.svelte
+++ b/src/routes/tests/issues/issue-414/+page.svelte
@@ -47,40 +47,19 @@
     let ariaLabel = $state<string | null>(null)
     let keyResults = $state<Record<string, boolean> | null>(null)
     let running = $state(false)
-    let probed = $state(false)
 
     const labeled = $derived(role === 'region' && !!ariaLabel)
     const keysPass = $derived(keyResults !== null && Object.values(keyResults).every(Boolean))
-    const keysLine = $derived(
-        keyResults === null
-            ? null
-            : KEY_PROBES.map((probe) => `${probe.stat}=${keyResults?.[probe.stat] ? 1 : 0}`).join(
-                  ' '
-              )
-    )
+    const keysLine = $derived.by(() => {
+        const results = keyResults
+        if (results === null) return null
+        return KEY_PROBES.map((probe) => `${probe.stat}=${results[probe.stat] ? 1 : 0}`).join(' ')
+    })
 
     const getViewport = (): HTMLElement | null =>
         document.querySelector('[data-testid="issue-414-list-viewport"]')
 
     const nextFrame = () => new Promise<void>((r) => requestAnimationFrame(() => r()))
-
-    /** Wait until scrollTop has been stable for a few frames (handles both
-     *  instant and smooth scrolling), bounded so a dead key resolves fast. */
-    const settleScroll = async (viewport: HTMLElement, maxMs = 800) => {
-        const start = performance.now()
-        let last = viewport.scrollTop
-        let stableFrames = 0
-        while (performance.now() - start < maxMs) {
-            await nextFrame()
-            if (viewport.scrollTop === last) {
-                stableFrames++
-                if (stableFrames >= 3) return
-            } else {
-                stableFrames = 0
-                last = viewport.scrollTop
-            }
-        }
-    }
 
     const runProbes = async () => {
         const viewport = getViewport()
@@ -117,7 +96,8 @@
                     cancelable: true
                 })
             )
-            await settleScroll(viewport)
+            // The component's key handler writes scrollTop synchronously, so
+            // the result is final as soon as dispatchEvent returns.
             const after = viewport.scrollTop
 
             switch (probe.expect) {
@@ -138,7 +118,6 @@
 
         keyResults = results
         running = false
-        probed = true
     }
 
     onMount(() => {
@@ -180,8 +159,8 @@
             >
         </div>
 
-        <div class="stat" class:pass={labeled} class:fail={probed && !labeled}>
-            <span class="light">{!probed && !labeled ? '…' : labeled ? '✓' : '✗'}</span>
+        <div class="stat" class:pass={labeled} class:fail={keyResults !== null && !labeled}>
+            <span class="light">{keyResults === null && !labeled ? '…' : labeled ? '✓' : '✗'}</span>
             <span class="label">labeled region for assistive tech</span>
             <span class="value" data-testid="stat-labeled">
                 role={role ?? 'none'} label={ariaLabel ? 'yes' : 'none'}

--- a/tests/issues/issue-414.spec.ts
+++ b/tests/issues/issue-414.spec.ts
@@ -25,17 +25,15 @@ test.describe('Issue 414 - keyboard accessibility for the viewport', () => {
         await expect(page.locator(stat('keys'))).toContainText('end=', { timeout: 15000 })
     })
 
-    test('viewport should be focusable', async ({ page }) => {
+    // One test, three assertion groups: all stats come from a single probe
+    // run, so separate tests would just reload the fixture and re-run the
+    // whole probe cycle per assertion group on every engine.
+    test('viewport is a focusable, labeled, keyboard-operable region', async ({ page }) => {
         await expect(page.locator(stat('focusable'))).toHaveText(/yes/)
-    })
 
-    test('viewport should be a labeled region for assistive tech', async ({ page }) => {
         await expect(page.locator(stat('labeled'))).toHaveText(/role=region label=yes/)
-    })
 
-    test('viewport should handle all standard scroll keys', async ({ page }) => {
         const keys = await readStats(page, 'keys')
-
         expect(keys.arrowDown).toBe(1)
         expect(keys.arrowUp).toBe(1)
         expect(keys.pageDown).toBe(1)

--- a/tests/issues/issue-414.spec.ts
+++ b/tests/issues/issue-414.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '@playwright/test'
+import { readStats, stat } from '../../src/lib/test/utils/statsLine.js'
+
+/**
+ * Issue #414 — Keyboard accessibility for the scroll viewport
+ *
+ * The viewport is a bare overflow-y: scroll div: keyboard users can only
+ * operate it where the browser happens to make scrollable divs focusable
+ * (Chrome/Firefox do, Safari does not), and assistive tech announces an
+ * unlabeled group. The component must expose a labeled role="region", be
+ * focusable, and handle the standard scroll keys itself.
+ *
+ * The fixture at /tests/issues/issue-414 probes everything and reports live
+ * pass/fail stats; these specs assert on those numbers. Its key probes use
+ * synthetic (untrusted) KeyboardEvents, which browsers never natively
+ * scroll from — every pass is the component's own keydown handler,
+ * deterministic across engines.
+ */
+
+test.describe('Issue 414 - keyboard accessibility for the viewport', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/issues/issue-414', { waitUntil: 'domcontentloaded' })
+        // The fixture auto-runs its probes shortly after mount; the key
+        // matrix is the last stat to fill in.
+        await expect(page.locator(stat('keys'))).toContainText('end=', { timeout: 15000 })
+    })
+
+    test('viewport should be focusable', async ({ page }) => {
+        await expect(page.locator(stat('focusable'))).toHaveText(/yes/)
+    })
+
+    test('viewport should be a labeled region for assistive tech', async ({ page }) => {
+        await expect(page.locator(stat('labeled'))).toHaveText(/role=region label=yes/)
+    })
+
+    test('viewport should handle all standard scroll keys', async ({ page }) => {
+        const keys = await readStats(page, 'keys')
+
+        expect(keys.arrowDown).toBe(1)
+        expect(keys.arrowUp).toBe(1)
+        expect(keys.pageDown).toBe(1)
+        expect(keys.pageUp).toBe(1)
+        expect(keys.space).toBe(1)
+        expect(keys.shiftSpace).toBe(1)
+        expect(keys.home).toBe(1)
+        expect(keys.end).toBe(1)
+    })
+})


### PR DESCRIPTION
## Summary

The scroll viewport was a bare `overflow-y: scroll` div: keyboard users could only operate it where the browser happens to make scrollable divs focusable (Chrome and Firefox do, **Safari does not focus it at all**), and assistive tech announced an unlabeled group. The viewport is now a focusable labeled region that owns the standard scroll keys itself, so behavior is identical on every engine — with a focus ring that survives both the component's `overflow: hidden` clipping and consumer styling.

Closes #414. This is the last of the three issues from the svelte-virtual-chat comparison (#412, #413, #414).

## Changes

✨ New features

- **Focusable labeled region** — the viewport renders with `role="region"`, `tabindex="0"`, and a new `viewportLabel` prop (default `'Scrollable list'`), making it a Tab stop and a named landmark in every engine.
- **Component-owned scroll keys** — arrows move a line (40px, matching native browser line scrolling), PageUp/PageDown and Space/Shift+Space move a page (viewport height minus one line of overlap), Home/End jump to the edges. Handled keys `preventDefault` so Space cannot page the document. Two deliberate guards: keys are only claimed when the viewport itself is focused (interactive item content — buttons, inputs — keeps native key behavior), and Ctrl/Meta/Alt chords pass through untouched. The key→target math is a pure `calculateKeyboardScrollTarget` in `scrollCalculation.ts` with unit coverage of every key, clamping, and tiny-viewport behavior; the handler gates on `isKeyboardScrollKey` before any layout reads so unhandled keys never force a reflow.
- **Clip-proof, un-loseable focus ring** — the default `:focus-visible` outline draws outside the element's box and was clipped away entirely by the container's `overflow: hidden`; the component now draws a 2px `currentColor` ring inset via `outline-offset: -2px`. It is keyed off the always-present role/tabindex attributes rather than the default viewport class, so passing a custom `viewportClass` cannot silently remove it (`:where()` keeps specificity low for restyling).
- **Scroll-intent arbitration** — keyboard input aborts an in-flight programmatic `scroll()` (the same supersede semantics a newer `scroll()` call gets), and `scroll()`'s deferred state write now checks its abort signal so a superseded scroll cannot clobber the newer position with its stale target.

🧪 Testing

- Self-reporting fixture at `/tests/issues/issue-414` with live red/green stats: focusability probe, role/aria-label semantics, and an 8-key scroll matrix driven by synthetic KeyboardEvents (untrusted, so browsers never natively scroll from them — every pass measures the component's own handler, deterministically across engines). Pre-fix it captured the engine split in CI: `focusable` passed on Chromium (native behavior) and failed on WebKit, with semantics and all 8 keys failing everywhere.
- Playwright spec asserts on the fixture's stats via the shared `statsLine` helpers; unit tests cover the region semantics, custom label, and the extracted key math (10 cases).

📚 Documentation

- New docs-site guide **`/docs/accessibility`** ("Keyboard & Accessibility" in the sidebar) with a live demo — a list with focus and last-scroll-key badges so visitors can Tab in and feel the keys working — covering why the component owns the keys, the binding table, `viewportLabel` guidance, the interactive-content guarantee, and focus-ring restyling. Verified against the dev server with real Tab presses (End lands at exactly `maxScrollTop`).
- `viewportLabel` in the README props table + docs props reference, plus an ♿ feature bullet.

## Verification

326 unit tests, `svelte-check` clean, and the full Playwright suite green on chromium, firefox, and webkit (204 passed / 0 failed after the consolidation pass; pre-fix the issue-414 spec failed 5 of 6 across chromium+webkit). Focus ring re-verified with real Tab keypresses against the docs site after every CSS change.

## Commits

- [`562ccee`](https://github.com/humanspeak/svelte-virtual-list/commit/562ccee649a8921534d0dc0093bf0688f825a770) test(virtual-list): add failing spec for keyboard viewport accessibility (#414)
- [`191d2c7`](https://github.com/humanspeak/svelte-virtual-list/commit/191d2c73f8dcc75677135fa795a06f11d0b2b807) feat(virtual-list): keyboard-accessible viewport with labeled region (#414)
- [`84e8d0d`](https://github.com/humanspeak/svelte-virtual-list/commit/84e8d0dcc516f166d2e0f084e0b1cbb748ae6846) docs(site): add Keyboard & Accessibility guide with live demo (#414)
- [`672f7f8`](https://github.com/humanspeak/svelte-virtual-list/commit/672f7f89169737de5d852811dc26efb867387de7) fix(virtual-list): draw the keyboard focus ring inside the viewport (#414)
- [`af958fa`](https://github.com/humanspeak/svelte-virtual-list/commit/af958fac3f47dcff52516015cb7b563144346b0b) refactor(virtual-list): extract keyboard scroll math and harden the focus ring after review (#414)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
