### PR TITLE
chore: gate CodeRabbit reviews behind the coderabbit label

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -65,10 +65,10 @@ reviews:
     abort_on_close: true
     disable_cache: false
     auto_review:
-        enabled: true
-        auto_incremental_review: true
+        enabled: false
+        auto_incremental_review: false
         ignore_title_keywords: []
-        labels: []
+        labels: ['coderabbit']
         drafts: false
         base_branches: []
     finishing_touches:


### PR DESCRIPTION
## What

Gates CodeRabbit auto-reviews behind the `coderabbit` label and stops per-push re-reviews, so simple fast-moving PRs no longer burn the hourly rate limit.

- `reviews.auto_review.enabled: false` — no automatic review on every PR
- `reviews.auto_review.labels: ['coderabbit']` — adding the `coderabbit` label triggers a review (per CodeRabbit docs, the labels trigger works even when `enabled` is false)
- `reviews.auto_review.auto_incremental_review: false` — pushes no longer re-trigger reviews

## How to invoke a review now

- Add the `coderabbit` label to the PR (created in this repo alongside this PR), or
- Comment `@coderabbitai review` (incremental) / `@coderabbitai full review` on any PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@coderabbitai ignore
