### PR TITLE
perf(virtual-list): block-accelerated offset/range math for deep scroll positions

### DIFF
--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -357,7 +357,8 @@
                 oldOffset: getScrollOffsetForIndex(
                     heightManager.getHeightCache(),
                     heightManager.averageHeight,
-                    index
+                    index,
+                    heightManager.getBlockSums()
                 )
             }
         }
@@ -396,7 +397,8 @@
                       newOffset: getScrollOffsetForIndex(
                           heightManager.getHeightCache(),
                           heightManager.averageHeight,
-                          anchor.index
+                          anchor.index,
+                          heightManager.getBlockSums()
                       )
                   },
             heightManager.viewport.scrollTop,
@@ -558,7 +560,8 @@
             totalItems: items.length,
             bufferSize,
             totalContentHeight: totalHeight,
-            heightCache: heightManager.getHeightCache()
+            heightCache: heightManager.getHeightCache(),
+            blockSums: heightManager.getBlockSums()
         })
 
         return lastVisibleRange
@@ -584,7 +587,8 @@
                 items.length,
                 visibleRange.start,
                 heightManager.averageHeight,
-                heightManager.getHeightCache()
+                heightManager.getHeightCache(),
+                heightManager.getBlockSums()
             )
         )
     })
@@ -633,7 +637,7 @@
             if (scrollDelta >= threshold || lastVisibleRange === null) {
                 lastProcessedScrollTop = current
             }
-            updateDebugTailDistance()
+            if (INTERNAL_DEBUG) updateDebugTailDistance()
             if (INTERNAL_DEBUG) {
                 const vr = visibleItems
                 log('[SVL] scroll', {
@@ -890,7 +894,8 @@
                 scrollTop: heightManager.scrollTop,
                 firstVisibleIndex,
                 lastVisibleIndex,
-                heightCache: heightManager.getHeightCache()
+                heightCache: heightManager.getHeightCache(),
+                blockSums: heightManager.getBlockSums()
             })
 
             // Handle early return for 'nearest' alignment when item is already visible

--- a/src/lib/reactive-list-manager/ReactiveListManager.svelte.ts
+++ b/src/lib/reactive-list-manager/ReactiveListManager.svelte.ts
@@ -81,6 +81,13 @@ export class ReactiveListManager {
                 ? current
                 : exactAverage
         this._averageHeight = average
+        // Block sums bake `average` into every unmeasured item's contribution;
+        // a hysteresis snap that moves the published average therefore
+        // invalidates any sums computed against the old value.
+        if (average !== current) {
+            this._blockSums.length = 0
+            this._blockSumsValid = false
+        }
         const unmeasuredCount = this._itemLength - this._measuredCount
         this._totalHeight = this._totalMeasuredHeight + unmeasuredCount * average
     }

--- a/src/lib/reactive-list-manager/ReactiveListManager.test.ts
+++ b/src/lib/reactive-list-manager/ReactiveListManager.test.ts
@@ -766,6 +766,38 @@ describe('ReactiveListManager (alias)', () => {
             expect(blockSums.length).toBe(0)
         })
 
+        it('should reflect a post-hysteresis-snap average in unmeasured tail blocks', () => {
+            // 3000 items, itemHeight 40 → published average starts at 40.
+            // blockSize 1000 → 3 blocks, blockSums has 2 prefix entries
+            // (block 0 = items 0-999, block 1 = items 0-1999).
+            const manager = new ReactiveListManager({ itemLength: 3000, itemHeight: 40 })
+
+            // Validate sums against the pre-snap average (40).
+            const before = manager.getBlockSums()
+            expect(before[0]).toBe(40000) // 1000 items × 40
+            expect(before[1]).toBe(80000) // 2000 items × 40
+
+            // Measure 100 items in block 0 at 200px. Exact average jumps to 200
+            // (|200-40|/40 = 4.0), far past the 2% hysteresis band, so the
+            // published average SNAPS to 200. Block sums bake that average into
+            // every unmeasured item, so the whole (untouched) tail must move.
+            const dirty = Array.from({ length: 100 }, (_, i) => ({
+                index: i,
+                oldHeight: undefined,
+                newHeight: 200
+            }))
+            manager.processDirtyHeights(dirty)
+            expect(manager.averageHeight).toBe(200)
+
+            const after = manager.getBlockSums()
+            // Block 0: 100 measured × 200 + 900 unmeasured × 200 = 200000.
+            expect(after[0]).toBe(200000)
+            // Block 1 is ENTIRELY unmeasured — if sums were stale (old avg 40)
+            // it would read 200000 + 1000×40 = 240000. With the snapped
+            // average it must read 200000 + 1000×200 = 400000.
+            expect(after[1]).toBe(400000)
+        })
+
         it('should perform efficiently with large item counts', () => {
             const manager = new ReactiveListManager({ itemLength: 100000, itemHeight: 40 })
 

--- a/src/lib/utils/scrollCalculation.test.ts
+++ b/src/lib/utils/scrollCalculation.test.ts
@@ -9,6 +9,7 @@ import {
     isKeyboardScrollKey,
     resolveAnchorScrollTarget
 } from './scrollCalculation.js'
+import { buildBlockSums, getValidHeight } from './virtualList.js'
 
 describe('alignToEdge', () => {
     // Common test setup: item at position 400-450, viewport 400px tall
@@ -624,5 +625,58 @@ describe('resolveAnchorScrollTarget', () => {
             // Drift is large but clamping brings the target back to scrollTop
             expect(resolveAnchorScrollTarget(item(100, 3000), 5000, maxScrollTop)).toBeNull()
         })
+    })
+})
+
+describe('calculateScrollTarget blockSums equivalence', () => {
+    const makeRng = (seed: number) => {
+        let s = seed >>> 0
+        return () => {
+            s = (s * 1664525 + 1013904223) >>> 0
+            return s / 0xffffffff
+        }
+    }
+
+    const TOTAL = 10_000
+    const AVG = 60
+
+    const buildSparseCache = (seed: number): Record<number, number> => {
+        const rng = makeRng(seed)
+        const cache: Record<number, number> = {}
+        for (let i = 0; i < TOTAL; i++) {
+            if (rng() < 0.3) cache[i] = 20 + Math.floor(rng() * 181)
+        }
+        return cache
+    }
+
+    it('returns identical targets with and without blockSums for every align mode', () => {
+        const cache = buildSparseCache(4242)
+        const blockSums = buildBlockSums(cache, AVG, TOTAL)
+
+        // A representative scroll geometry: viewport somewhere in the middle.
+        let scrollTop = 0
+        for (let i = 0; i < 4000; i++) scrollTop += getValidHeight(cache[i], AVG)
+
+        const aligns: ScrollTargetParams['align'][] = ['auto', 'top', 'bottom', 'nearest']
+        const targets = [0, 1, 500, 999, 1000, 1001, 4000, 4005, 5000, 9500, 9999]
+
+        for (const align of aligns) {
+            for (const targetIndex of targets) {
+                const base: ScrollTargetParams = {
+                    align,
+                    targetIndex,
+                    itemsLength: TOTAL,
+                    calculatedItemHeight: AVG,
+                    height: 400,
+                    scrollTop,
+                    firstVisibleIndex: 4000,
+                    lastVisibleIndex: 4010,
+                    heightCache: cache
+                }
+                const legacy = calculateScrollTarget(base)
+                const accelerated = calculateScrollTarget({ ...base, blockSums })
+                expect(accelerated, `align=${align} target=${targetIndex}`).toBe(legacy)
+            }
+        }
     })
 })

--- a/src/lib/utils/scrollCalculation.ts
+++ b/src/lib/utils/scrollCalculation.ts
@@ -200,6 +200,8 @@ export interface ScrollTargetParams {
     firstVisibleIndex: number
     lastVisibleIndex: number
     heightCache: Record<number, number>
+    /** Optional precomputed block sums for O(blockSize) offset lookup (see buildBlockSums). */
+    blockSums?: number[]
 }
 
 /**
@@ -239,7 +241,8 @@ export const calculateScrollTarget = (params: ScrollTargetParams): number | null
         scrollTop,
         firstVisibleIndex,
         lastVisibleIndex,
-        heightCache
+        heightCache,
+        blockSums
     } = params
 
     return calculateTopToBottomScrollTarget({
@@ -250,7 +253,8 @@ export const calculateScrollTarget = (params: ScrollTargetParams): number | null
         scrollTop,
         firstVisibleIndex,
         lastVisibleIndex,
-        heightCache
+        heightCache,
+        blockSums
     })
 }
 
@@ -276,6 +280,8 @@ interface TopToBottomScrollParams {
     lastVisibleIndex: number
     /** Cache of measured item heights. */
     heightCache: Record<number, number>
+    /** Optional precomputed block sums for O(blockSize) offset lookup (see buildBlockSums). */
+    blockSums?: number[]
 }
 
 /**
@@ -298,12 +304,23 @@ const calculateTopToBottomScrollTarget = (params: TopToBottomScrollParams): numb
         scrollTop,
         firstVisibleIndex,
         lastVisibleIndex,
-        heightCache
+        heightCache,
+        blockSums
     } = params
 
     // Calculate item boundaries
-    const itemTop = getScrollOffsetForIndex(heightCache, calculatedItemHeight, targetIndex)
-    const itemBottom = getScrollOffsetForIndex(heightCache, calculatedItemHeight, targetIndex + 1)
+    const itemTop = getScrollOffsetForIndex(
+        heightCache,
+        calculatedItemHeight,
+        targetIndex,
+        blockSums
+    )
+    const itemBottom = getScrollOffsetForIndex(
+        heightCache,
+        calculatedItemHeight,
+        targetIndex + 1,
+        blockSums
+    )
 
     if (align === 'auto') {
         // If item is above the viewport, align to top

--- a/src/lib/utils/virtualList.perf-budget.test.ts
+++ b/src/lib/utils/virtualList.perf-budget.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { calculateScrollTarget } from './scrollCalculation.js'
+import { buildBlockSums, calculateTransformY, calculateVisibleRange } from './virtualList.js'
+
+const TOTAL = 100_000
+const HEIGHT = 40
+
+const makeCountingCache = () => {
+    const cache: Record<number, number> = {}
+    for (let i = 0; i < TOTAL; i++) cache[i] = HEIGHT
+    let reads = 0
+    const proxy = new Proxy(cache, {
+        get(target, prop, receiver) {
+            reads += 1
+            return Reflect.get(target, prop, receiver)
+        }
+    })
+    return { proxy, readCount: () => reads }
+}
+
+describe('offset/range math read budgets (PERF-01/PERF-02)', () => {
+    it('calculateVisibleRange near the end of 100k items stays within budget', () => {
+        const { proxy, readCount } = makeCountingCache()
+        const blockSums = buildBlockSums(proxy, HEIGHT, TOTAL)
+        const after = readCount() // buildBlockSums legitimately reads everything once
+        calculateVisibleRange({
+            scrollTop: TOTAL * HEIGHT - 10_000,
+            viewportHeight: 400,
+            itemHeight: HEIGHT,
+            totalItems: TOTAL,
+            bufferSize: 20,
+            totalContentHeight: TOTAL * HEIGHT,
+            heightCache: proxy,
+            blockSums
+        })
+        expect(readCount() - after).toBeLessThan(5_000)
+    })
+
+    it('calculateTransformY near the end of 100k items stays within budget', () => {
+        const { proxy, readCount } = makeCountingCache()
+        const blockSums = buildBlockSums(proxy, HEIGHT, TOTAL)
+        const after = readCount()
+        calculateTransformY(TOTAL, 90_000, HEIGHT, proxy, blockSums)
+        expect(readCount() - after).toBeLessThan(5_000)
+    })
+
+    it('calculateScrollTarget near the end of 100k items stays within budget', () => {
+        const { proxy, readCount } = makeCountingCache()
+        const blockSums = buildBlockSums(proxy, HEIGHT, TOTAL)
+        const after = readCount()
+        calculateScrollTarget({
+            align: 'top',
+            targetIndex: 90_000,
+            itemsLength: TOTAL,
+            calculatedItemHeight: HEIGHT,
+            height: 400,
+            scrollTop: 0,
+            firstVisibleIndex: 0,
+            lastVisibleIndex: 10,
+            heightCache: proxy,
+            blockSums
+        })
+        expect(readCount() - after).toBeLessThan(5_000)
+    })
+})

--- a/src/lib/utils/virtualList.test.ts
+++ b/src/lib/utils/virtualList.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+    buildBlockSums,
     calculateScrollPosition,
     calculateTransformY,
     calculateVisibleRange,
@@ -505,5 +506,81 @@ describe('collectPitchChanges', () => {
             { index: 1, oldHeight: undefined, newHeight: 40 },
             { index: 3, oldHeight: 40, newHeight: 80 }
         ])
+    })
+})
+
+describe('calculateVisibleRange blockSums equivalence', () => {
+    // Small seeded LCG so the sparse cache is deterministic across runs.
+    const makeRng = (seed: number) => {
+        let s = seed >>> 0
+        return () => {
+            s = (s * 1664525 + 1013904223) >>> 0
+            return s / 0xffffffff
+        }
+    }
+
+    const TOTAL = 10_000
+    const AVG = 60
+
+    // ~30% of items measured with heights in [20, 200]; the rest fall back to AVG.
+    const buildSparseCache = (seed: number): Record<number, number> => {
+        const rng = makeRng(seed)
+        const cache: Record<number, number> = {}
+        for (let i = 0; i < TOTAL; i++) {
+            if (rng() < 0.3) {
+                cache[i] = 20 + Math.floor(rng() * 181) // 20..200
+            }
+        }
+        return cache
+    }
+
+    it('returns identical {start,end} with and without blockSums across a scrollTop sweep', () => {
+        const cache = buildSparseCache(12345)
+        const blockSums = buildBlockSums(cache, AVG, TOTAL)
+
+        // Total content height by the same accounting the range math uses.
+        let totalContentHeight = 0
+        for (let i = 0; i < TOTAL; i++) {
+            totalContentHeight += getValidHeight(cache[i], AVG)
+        }
+        const viewportHeight = 400
+        const maxScrollTop = Math.max(0, totalContentHeight - viewportHeight)
+
+        const scrollTops = [
+            0,
+            1,
+            123,
+            Math.floor(maxScrollTop * 0.25),
+            Math.floor(maxScrollTop * 0.5),
+            Math.floor(maxScrollTop * 0.75),
+            maxScrollTop - 1000,
+            maxScrollTop - 10,
+            maxScrollTop
+        ]
+
+        for (const scrollTop of scrollTops) {
+            const base = {
+                scrollTop,
+                viewportHeight,
+                itemHeight: AVG,
+                totalItems: TOTAL,
+                bufferSize: 5,
+                totalContentHeight,
+                heightCache: cache
+            }
+            const legacy = calculateVisibleRange(base)
+            const accelerated = calculateVisibleRange({ ...base, blockSums })
+            expect(accelerated, `scrollTop=${scrollTop}`).toEqual(legacy)
+        }
+    })
+
+    it('calculateTransformY returns identical offsets with and without blockSums', () => {
+        const cache = buildSparseCache(999)
+        const blockSums = buildBlockSums(cache, AVG, TOTAL)
+        for (const idx of [0, 1, 500, 999, 1000, 1001, 5000, 9500, 9999]) {
+            const legacy = calculateTransformY(TOTAL, idx, AVG, cache)
+            const accelerated = calculateTransformY(TOTAL, idx, AVG, cache, blockSums)
+            expect(accelerated, `idx=${idx}`).toBe(legacy)
+        }
     })
 })

--- a/src/lib/utils/virtualList.ts
+++ b/src/lib/utils/virtualList.ts
@@ -79,6 +79,15 @@ export interface VisibleRangeOptions {
     totalContentHeight?: number
     /** Measured item heights keyed by index; used to walk actual heights instead of dividing by average. */
     heightCache?: Record<number, number>
+    /**
+     * Optional precomputed block prefix sums (see {@link buildBlockSums}). When
+     * present and non-empty, the start index is found by binary-searching the
+     * blocks instead of accumulating heights from index 0 — O(blockSize)
+     * instead of O(start). Must be built with the same `blockSize`.
+     */
+    blockSums?: number[]
+    /** Block size the `blockSums` were built with (default 1000). */
+    blockSize?: number
 }
 
 /**
@@ -110,12 +119,33 @@ export const calculateVisibleRange = ({
     totalItems,
     bufferSize,
     totalContentHeight,
-    heightCache
+    heightCache,
+    blockSums,
+    blockSize = 1000
 }: VisibleRangeOptions): SvelteVirtualListPreviousVisibleRange => {
     // Walk forward through measured heights to find the correct start index
     // instead of dividing by average height (which is wrong for variable-height items).
     let start = 0
     let acc = 0
+    if (blockSums && blockSums.length > 0) {
+        // Block-accelerated start: binary-search for the smallest completed
+        // block whose cumulative height exceeds scrollTop, seed acc/start from
+        // it, then finish with a bounded walk (≤ blockSize iterations). This
+        // replaces the O(start) walk from index 0 with O(blockSize).
+        let lo = 0
+        let hi = blockSums.length
+        while (lo < hi) {
+            const mid = (lo + hi) >> 1
+            if (blockSums[mid] > scrollTop) {
+                hi = mid
+            } else {
+                lo = mid + 1
+            }
+        }
+        const b = lo
+        acc = b > 0 ? blockSums[b - 1] : 0
+        start = b * blockSize
+    }
     while (start < totalItems) {
         const h = getValidHeight(heightCache?.[start], itemHeight)
         if (acc + h > scrollTop) break
@@ -174,17 +204,19 @@ export const calculateVisibleRange = ({
  * @param {number} visibleStart - Index of the first visible item
  * @param {number} itemHeight - Height of each list item in pixels
  * @param {Record<number, number>} [heightCache] - Cache of measured item heights
+ * @param {number[]} [blockSums] - Optional precomputed block sums for O(blockSize) offset lookup
  * @returns {number} The calculated transform Y value in pixels
  */
 export const calculateTransformY = (
     totalItems: number,
     visibleStart: number,
     itemHeight: number,
-    heightCache?: Record<number, number>
+    heightCache?: Record<number, number>,
+    blockSums?: number[]
 ) => {
     // Prefer precise offset using measured heights when available
     if (heightCache) {
-        const offset = getScrollOffsetForIndex(heightCache, itemHeight, visibleStart)
+        const offset = getScrollOffsetForIndex(heightCache, itemHeight, visibleStart, blockSums)
         return Math.max(0, Math.round(offset))
     }
     return Math.round(visibleStart * itemHeight)
@@ -304,14 +336,21 @@ export const getScrollOffsetForIndex = (
 
         return offset
     }
+    // Clamp to the last stored block sum. `blockSums` holds one entry per
+    // COMPLETED block (blocks - 1 entries), so an index at or beyond the final
+    // block's start — e.g. idx === totalItems when totalItems is a multiple of
+    // blockSize — has no prefix entry of its own. Seeding from the last
+    // available sum and walking the remainder keeps the result correct instead
+    // of reading `undefined` and collapsing to 0.
     const blockIdx = Math.floor(safeIdx / blockSize)
+    const effBlock = Math.min(blockIdx, blockSums.length)
     let offsetBase = 0
-    if (blockIdx > 0) {
-        const base = blockSums[blockIdx - 1]
+    if (effBlock > 0) {
+        const base = blockSums[effBlock - 1]
         offsetBase = Number.isFinite(base) ? (base as number) : 0
     }
     let offset = offsetBase
-    const start = blockIdx * blockSize
+    const start = effBlock * blockSize
     for (let i = start; i < safeIdx; i++) {
         offset += getValidHeight(heightCache[i], calculatedItemHeight)
     }

--- a/src/routes/tests/other/tail-scroll-cost/+page.svelte
+++ b/src/routes/tests/other/tail-scroll-cost/+page.svelte
@@ -1,0 +1,284 @@
+<script lang="ts">
+    import { onMount } from 'svelte'
+    import SvelteVirtualList from '$lib/index.js'
+
+    type Item = {
+        id: number
+        text: string
+    }
+
+    // 200k items: large enough that an O(n) prefix walk near the tail is
+    // orders of magnitude more work than the same walk near the head.
+    const ITEM_COUNT = 200_000
+    const ITEM_HEIGHT_PX = 40
+    const STEP_PX = 1_000
+    const STEPS = 15
+    const RATIO_LIMIT = 3
+
+    const items: Item[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    }))
+
+    let headMs = $state<number | null>(null)
+    let tailMs = $state<number | null>(null)
+    let ratio = $state<number | null>(null)
+    let running = $state(false)
+
+    const ratioPass = $derived(ratio !== null && ratio < RATIO_LIMIT)
+
+    const getViewport = (): HTMLElement | null =>
+        document.querySelector('[data-testid="tail-cost-list-viewport"]')
+
+    const settle = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+    const nextFrame = () => new Promise<void>((r) => requestAnimationFrame(() => r()))
+
+    const median = (values: number[]): number => {
+        const sorted = [...values].sort((a, b) => a - b)
+        const mid = Math.floor(sorted.length / 2)
+        return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+    }
+
+    /**
+     * Times STEPS scroll steps of STEP_PX each: scrollTop += step, then wait
+     * for the next animation frame so the visible-range recompute and paint
+     * are inside the measured window. Returns the median step cost in ms.
+     */
+    const timeScrollSteps = async (viewport: HTMLElement): Promise<number> => {
+        const samples: number[] = []
+        for (let i = 0; i < STEPS; i++) {
+            const start = performance.now()
+            viewport.scrollTop += STEP_PX
+            await nextFrame()
+            samples.push(performance.now() - start)
+            // Delay between steps is excluded from the timing.
+            await settle(50)
+        }
+        return median(samples)
+    }
+
+    const runProbe = async () => {
+        const viewport = getViewport()
+        if (!viewport || running) return
+        running = true
+        headMs = null
+        tailMs = null
+        ratio = null
+
+        // Settle at the top, then time the head steps.
+        viewport.scrollTop = 0
+        await settle(400)
+        const head = await timeScrollSteps(viewport)
+
+        // Jump to ~95% depth, settle, and repeat the identical steps.
+        const maxScrollTop = viewport.scrollHeight - viewport.clientHeight
+        viewport.scrollTop = Math.floor(maxScrollTop * 0.95)
+        await settle(400)
+        const tail = await timeScrollSteps(viewport)
+
+        headMs = Math.round(head * 100) / 100
+        tailMs = Math.round(tail * 100) / 100
+        // Some engines coarsen performance.now() to ~1ms ticks (WebKit), so
+        // sub-ms medians quantize to 0 and one or two ticks of paint noise at
+        // the tail could fabricate a huge ratio against a zero head. Floor
+        // both medians at two clock ticks: quantization then reads as ratio
+        // ~1-2, while a real O(n) tail regression (tens of ms of prefix
+        // walking against a ~0ms head) still trips the limit unmistakably.
+        const FLOOR_MS = 2
+        ratio = Math.round((Math.max(tail, FLOOR_MS) / Math.max(head, FLOOR_MS)) * 100) / 100
+        running = false
+    }
+
+    onMount(() => {
+        const timer = setTimeout(runProbe, 500)
+        return () => clearTimeout(timer)
+    })
+</script>
+
+<div class="page">
+    <h1>Tail scroll cost — end-of-list scrolling must not pay O(n)</h1>
+
+    <div class="description">
+        <p>
+            <strong>What:</strong> the visible-range and transform math walk item heights to turn a
+            <code>scrollTop</code> into a start index and pixel offset. Without block prefix-sum acceleration
+            those walks start at index 0, so their cost grows linearly with scroll depth: near item 190,000
+            every scroll frame walks ~190,000 height lookups that a frame near the top never pays.
+        </p>
+        <p>
+            <strong>Why it's bad:</strong> the same gesture gets slower the deeper the user scrolls —
+            the end of a large list is measurably heavier than the top, on a component that advertises
+            O(1) height management.
+        </p>
+        <p>
+            <strong>How it's measured:</strong> the probe settles at the top and performs {STEPS}
+            scroll steps of {STEP_PX}px, timing each <code>scrollTop += step</code> to the next
+            animation frame; the median is <code>headMs</code>. It then jumps to ~95% depth and
+            repeats the identical steps for <code>tailMs</code>. The pass condition is
+            <code>ratio &lt; {RATIO_LIMIT}</code> — a generous regression tripwire, not a benchmark; the
+            precise gate is the read-budget unit tests.
+        </p>
+    </div>
+
+    <div class="stats" data-testid="tail-cost-stats">
+        <div class="stat" class:pass={ratioPass} class:fail={ratio !== null && !ratioPass}>
+            <span class="light"
+                >{ratio === null ? (running ? '⟳' : '…') : ratioPass ? '✓' : '✗'}</span
+            >
+            <span class="label">tail steps cost like head steps</span>
+            <span class="value" data-testid="stat-tailcost">
+                headMs={headMs ?? '—'} tailMs={tailMs ?? '—'} ratio={ratio ?? '—'}
+            </span>
+            <span class="expected">
+                ratio must stay below {RATIO_LIMIT} — anything higher means scroll depth is buying back
+                the O(n) walk
+            </span>
+        </div>
+
+        <button class="remeasure" onclick={runProbe} disabled={running}>
+            {running ? 'probing…' : 'Re-run probe'}
+        </button>
+    </div>
+
+    <div class="test-container">
+        <SvelteVirtualList
+            defaultEstimatedItemHeight={ITEM_HEIGHT_PX}
+            {items}
+            testId="tail-cost-list"
+        >
+            {#snippet renderItem(item)}
+                <div class="fixed-item" style="height: {ITEM_HEIGHT_PX}px;">
+                    {item.text}
+                </div>
+            {/snippet}
+        </SvelteVirtualList>
+    </div>
+</div>
+
+<style>
+    .page {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 16px;
+        font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
+    }
+
+    h1 {
+        font-size: 18px;
+        margin: 0 0 12px;
+    }
+
+    .description {
+        font-size: 13px;
+        line-height: 1.5;
+        color: #333;
+        background: #fafafa;
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 4px 14px;
+        margin-bottom: 12px;
+    }
+
+    .description code {
+        background: #eef2f7;
+        padding: 1px 4px;
+        border-radius: 3px;
+    }
+
+    .stats {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 12px;
+        font-size: 13px;
+    }
+
+    .stat {
+        display: grid;
+        grid-template-columns: 22px 230px minmax(120px, auto) 1fr;
+        gap: 8px;
+        align-items: baseline;
+        padding: 6px 10px;
+        border-radius: 6px;
+        border: 1px solid #e5e5e5;
+        background: #f6f6f6;
+    }
+
+    .stat.pass {
+        background: #e9f7ee;
+        border-color: #b7e2c4;
+    }
+
+    .stat.fail {
+        background: #fdeaea;
+        border-color: #f2b8b8;
+    }
+
+    .light {
+        font-weight: 700;
+    }
+
+    .stat.pass .light {
+        color: #1a7f37;
+    }
+
+    .stat.fail .light {
+        color: #c62828;
+    }
+
+    .label {
+        font-weight: 600;
+    }
+
+    .value {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+    }
+
+    .stat.pass .value {
+        color: #1a7f37;
+    }
+
+    .stat.fail .value {
+        color: #c62828;
+    }
+
+    .expected {
+        color: #777;
+        font-size: 12px;
+    }
+
+    .remeasure {
+        align-self: flex-start;
+        margin-top: 4px;
+        padding: 6px 14px;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 13px;
+    }
+
+    .remeasure:disabled {
+        opacity: 0.6;
+        cursor: wait;
+    }
+
+    /* Solid failure backdrop: if the list fails to render, this red shows. */
+    .test-container {
+        width: 100%;
+        height: 500px;
+        background: #ffc2c2;
+    }
+
+    .fixed-item {
+        box-sizing: border-box;
+        padding: 8px 12px;
+        border-bottom: 1px solid #eee;
+        background: #fff;
+        font-size: 14px;
+    }
+</style>

--- a/tests/other/tail-scroll-cost.spec.ts
+++ b/tests/other/tail-scroll-cost.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test'
+import { readStats, stat } from '../../src/lib/test/utils/statsLine.js'
+
+/**
+ * Tail scroll cost — end-of-list scrolling must not pay O(n)
+ *
+ * Before the block prefix-sum acceleration was wired through the component,
+ * every visible-range recompute and transform walked item heights from index
+ * 0, so a scroll frame near item 190,000 of a 200,000-item list did ~190,000
+ * sparse-object lookups that a frame near the top never paid.
+ *
+ * The fixture at /tests/other/tail-scroll-cost times 15 identical 1,000px
+ * scroll steps at the top (headMs, median) and at ~95% depth (tailMs,
+ * median) and reports tail/head as `ratio`. This spec asserts on the
+ * fixture's own stats line. The 3x threshold is a generous regression
+ * tripwire, not a benchmark — the precise gate is the read-budget unit
+ * tests in src/lib/utils/virtualList.perf-budget.test.ts.
+ */
+
+test.describe('Tail scroll cost - block-accelerated offset math', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/other/tail-scroll-cost', { waitUntil: 'domcontentloaded' })
+        // The fixture auto-runs its probe shortly after mount. Require a
+        // digit: the pre-probe placeholder is the dash in "ratio=—".
+        await expect(page.locator(stat('tailcost'))).toContainText(/ratio=[\d.]+/, {
+            timeout: 25000
+        })
+    })
+
+    test('scroll steps near the tail cost about the same as near the head', async ({ page }) => {
+        const stats = await readStats(page, 'tailcost')
+
+        // Fixture sanity: both medians were actually measured.
+        expect(Number.isFinite(stats.headMs)).toBe(true)
+        expect(Number.isFinite(stats.tailMs)).toBe(true)
+
+        // The real assertion: scroll depth must not buy back the O(n) walk.
+        expect(stats.ratio).toBeLessThan(3)
+    })
+})


### PR DESCRIPTION
## Summary

Wires the repo's existing-but-dormant block prefix-sum acceleration (`buildBlockSums` / `getBlockSums()`) into every positional hot path, so scrolling near the end of a large list stops paying an O(n) height walk per frame. Before this change, a frame near item 90,000 of 100,000 walked ~90k sparse-object lookups in `calculateVisibleRange` and again in `transformY` — the tail of a big list was measurably heavier than the head. After it, recovery from any long jump is depth-independent (~2 frames at 10% and at 99% of a 200k list, measured).

Executed from plan `.agents/.plans/perf-parity/001` with independent guard review: all done criteria reproduced (315 unit / 350 e2e across 5 engines / trunk clean), read-budget red tests went 99,761→<5,000 reads.

## Changes

- 🔧 `calculateVisibleRange`: binary-search the start block via `blockSums` instead of accumulating heights from index 0 (O(blockSize) worst case)
- 🔧 Thread `blockSums` through `calculateTransformY`, `calculateScrollTarget`, and the resize anchor capture/restore — all five component call sites now use `heightManager.getBlockSums()`
- 🐛 Fix a latent bug in `getScrollOffsetForIndex`'s fast path: a block-aligned index at/past the last stored sum read `undefined` and silently collapsed the offset to 0 (`effBlock` clamp; regression-pinned by the equivalence tests)
- 🐛 `ReactiveListManager`: invalidate block sums when the published average moves (hysteresis snap) — sums bake the average into every unmeasured item
- 🔧 Gate `updateDebugTailDistance()` behind `INTERNAL_DEBUG` — it forced a `querySelector` + two layout reads on every scroll frame even with debug off
- 🧪 Read-budget tests (counting-Proxy, <5,000 reads at 100k depth), seeded equivalence sweeps (accelerated ≡ legacy for ranges and scroll targets), manager staleness test
- 🧪 New self-judging fixture `/tests/other/tail-scroll-cost` (200k items, head-vs-tail median step cost, ratio < 3) + Playwright spec asserting the page's own stats

## Commits

- [`e0b42ce`](https://github.com/humanspeak/svelte-virtual-list/commit/e0b42cef28fb7dffa80c845dcbd552ccbe2c735a) perf(virtual-list): wire block prefix sums into offset and range math
- [`6eb6f97`](https://github.com/humanspeak/svelte-virtual-list/commit/6eb6f97020f68aa2cc8d6f8885bd451fe7981b23) test(virtual-list): add tail-scroll-cost fixture and e2e regression tripwire

🤖 Generated with [Claude Code](https://claude.com/claude-code)
