### PR TITLE
feat(virtual-list): public onRangeChange callback for visible-range state

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ yarn add @humanspeak/svelte-virtual-list
 | `onLoadMore`                 | `() => void \| Promise<void>` | -                   | Callback when more data is needed for infinite scroll                         |
 | `loadMoreThreshold`          | `number`                      | `20`                | Items from end to trigger `onLoadMore`                                        |
 | `hasMore`                    | `boolean`                     | `true`              | Set to `false` when all data has been loaded                                  |
+| `onRangeChange`              | `(range) => void`             | -                   | Fires when the rendered range or at-top/at-bottom state changes               |
+
+### Observing the visible range
+
+`onRangeChange` delivers a `{ start, end, atTop, atBottom }` snapshot whenever the rendered
+item range or the scroll edges change (it also fires once after mount with the initial range).
+Use it for impression/analytics tracking, URL sync, sticky toolbars, or scroll-position
+persistence — no need to enable `debug`. `start`/`end` include the render buffer.
+
+```svelte
+<SvelteVirtualList
+    {items}
+    onRangeChange={({ start, end, atTop, atBottom }) => {
+        console.log(`rendering ${start}..${end}`, { atTop, atBottom })
+    }}
+>
+    {#snippet renderItem(item)}
+        <div>{item.text}</div>
+    {/snippet}
+</SvelteVirtualList>
+```
 
 ## Programmatic Scrolling
 
@@ -241,18 +262,18 @@ This project uses [Trunk](https://trunk.io) for formatting and linting. Trunk ma
 
 Part of the [Humanspeak](https://humanspeak.com) family of runes-native Svelte 5 packages:
 
-| Package | Description |
-| --- | --- |
-| [@humanspeak/svelte-markdown](https://markdown.svelte.page) | Runtime markdown renderer for Svelte |
-| **[@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)** — _this package_ | Virtual scrolling for Svelte |
-| [@humanspeak/svelte-motion](https://motion.svelte.page) | Framer Motion for Svelte 5 |
-| [@humanspeak/svelte-headless-table](https://table.svelte.page) | Headless data tables for Svelte |
-| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page) | Diff comparison for Svelte |
-| [@humanspeak/svelte-purify](https://purify.svelte.page) | HTML sanitisation for Svelte |
-| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page) | Virtual chat viewport for Svelte 5 |
-| [@humanspeak/memory-cache](https://memory.svelte.page) | In-memory cache for TypeScript |
-| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page) | JSON tree viewer for Svelte 5 |
-| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page) | Scoped class props for Svelte |
+| Package                                                                                 | Description                          |
+| --------------------------------------------------------------------------------------- | ------------------------------------ |
+| [@humanspeak/svelte-markdown](https://markdown.svelte.page)                             | Runtime markdown renderer for Svelte |
+| **[@humanspeak/svelte-virtual-list](https://virtuallist.svelte.page)** — _this package_ | Virtual scrolling for Svelte         |
+| [@humanspeak/svelte-motion](https://motion.svelte.page)                                 | Framer Motion for Svelte 5           |
+| [@humanspeak/svelte-headless-table](https://table.svelte.page)                          | Headless data tables for Svelte      |
+| [@humanspeak/svelte-diff-match-patch](https://diff.svelte.page)                         | Diff comparison for Svelte           |
+| [@humanspeak/svelte-purify](https://purify.svelte.page)                                 | HTML sanitisation for Svelte         |
+| [@humanspeak/svelte-virtual-chat](https://virtualchat.svelte.page)                      | Virtual chat viewport for Svelte 5   |
+| [@humanspeak/memory-cache](https://memory.svelte.page)                                  | In-memory cache for TypeScript       |
+| [@humanspeak/svelte-json-view-lite](https://jsonview.svelte.page)                       | JSON tree viewer for Svelte 5        |
+| [@humanspeak/svelte-scoped-props](https://scoped.svelte.page)                           | Scoped class props for Svelte        |
 
 ## License
 

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -148,6 +148,7 @@
         DEFAULT_SCROLL_OPTIONS,
         type SvelteVirtualListPreviousVisibleRange,
         type SvelteVirtualListProps,
+        type SvelteVirtualListRangeInfo,
         type SvelteVirtualListScrollOptions
     } from '$lib/types.js'
     import { createRafScheduler } from '$lib/utils/raf.js'
@@ -198,7 +199,8 @@
         testId, // Base test ID for component elements (undefined = no data-testid attributes)
         onLoadMore, // Callback when more data needed (supports sync and async)
         loadMoreThreshold = 20, // Items from end to trigger load
-        hasMore = true // Set false when all data loaded
+        hasMore = true, // Set false when all data loaded
+        onRangeChange // Public callback for visible-range / scroll-edge changes
     }: SvelteVirtualListProps<TItem> = $props()
 
     /**
@@ -750,6 +752,32 @@
         } else {
             console.info('Virtual List Debug:', info)
         }
+    })
+
+    // Public range/scroll-edge callback. Mirrors the debug effect's shape but
+    // delivers a trimmed, first-class payload (no debug gating, no console
+    // noise). lastRangeInfo is a plain `let` — NOT $state — because writing
+    // $state inside an effect that also reads it would loop.
+    let lastRangeInfo: SvelteVirtualListRangeInfo | null = null
+
+    $effect(() => {
+        if (!onRangeChange) return
+        const range = visibleItems
+        const viewportHeight = height || 0
+        // atTop/atBottom math intentionally matches createDebugInfo
+        // (virtualListDebug.ts) so the two channels can never disagree.
+        const atTop = heightManager.scrollTop <= 1
+        const atBottom = heightManager.scrollTop >= totalHeight - viewportHeight - 1
+        if (
+            lastRangeInfo &&
+            lastRangeInfo.start === range.start &&
+            lastRangeInfo.end === range.end &&
+            lastRangeInfo.atTop === atTop &&
+            lastRangeInfo.atBottom === atBottom
+        )
+            return
+        lastRangeInfo = { start: range.start, end: range.end, atTop, atBottom }
+        onRangeChange(lastRangeInfo)
     })
 
     /**

--- a/src/lib/SvelteVirtualList.test.ts
+++ b/src/lib/SvelteVirtualList.test.ts
@@ -228,6 +228,112 @@ describe('SvelteVirtualList Component', () => {
         })
     })
 
+    describe('onRangeChange Callback', () => {
+        test('fires at least once after mount with the initial range', async () => {
+            const onRangeChange = vi.fn()
+            const items = createMockItems(100)
+
+            render(TestWrapper, {
+                props: {
+                    testId: 'test-list',
+                    items,
+                    onRangeChange
+                }
+            })
+
+            await vi.runAllTimersAsync()
+            await tick()
+
+            expect(onRangeChange).toHaveBeenCalled()
+
+            const lastCall = onRangeChange.mock.calls[onRangeChange.mock.calls.length - 1][0]
+            expect(lastCall.start).toBe(0)
+            expect(lastCall.end).toBeGreaterThan(0)
+            expect(lastCall.atTop).toBe(true)
+        })
+
+        test('does not re-deliver identical payloads on unrelated re-renders', async () => {
+            const onRangeChange = vi.fn()
+            const items = createMockItems(100)
+
+            const { rerender } = render(TestWrapper, {
+                props: {
+                    testId: 'test-list',
+                    items,
+                    onRangeChange
+                }
+            })
+
+            await vi.runAllTimersAsync()
+            await tick()
+
+            const countAfterSettle = onRangeChange.mock.calls.length
+            expect(countAfterSettle).toBeGreaterThan(0)
+
+            // Force an unrelated re-render with the same props/state.
+            await rerender({
+                testId: 'test-list',
+                items,
+                onRangeChange
+            })
+            await vi.runAllTimersAsync()
+            await tick()
+
+            expect(onRangeChange.mock.calls.length).toBe(countAfterSettle)
+        })
+
+        test('every payload has exactly {start, end, atTop, atBottom} with correct types', async () => {
+            const onRangeChange = vi.fn()
+            const items = createMockItems(100)
+
+            render(TestWrapper, {
+                props: {
+                    testId: 'test-list',
+                    items,
+                    onRangeChange
+                }
+            })
+
+            await vi.runAllTimersAsync()
+            await tick()
+
+            expect(onRangeChange).toHaveBeenCalled()
+            for (const [payload] of onRangeChange.mock.calls) {
+                expect(Object.keys(payload).sort()).toEqual(
+                    ['atBottom', 'atTop', 'end', 'start'].sort()
+                )
+                expect(typeof payload.start).toBe('number')
+                expect(typeof payload.end).toBe('number')
+                expect(typeof payload.atTop).toBe('boolean')
+                expect(typeof payload.atBottom).toBe('boolean')
+            }
+        })
+
+        test('mounting without onRangeChange does not throw or warn', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+            const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+            const items = createMockItems(100)
+
+            expect(() => {
+                render(TestWrapper, {
+                    props: {
+                        testId: 'test-list',
+                        items
+                    }
+                })
+            }).not.toThrow()
+
+            await vi.runAllTimersAsync()
+            await tick()
+
+            expect(warnSpy).not.toHaveBeenCalled()
+            expect(errorSpy).not.toHaveBeenCalled()
+
+            warnSpy.mockRestore()
+            errorSpy.mockRestore()
+        })
+    })
+
     describe('Height Management', () => {
         test('handles different item heights', async () => {
             const items = createMockItems(10)

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,6 +2,7 @@ import SvelteVirtualList from '$lib/SvelteVirtualList.svelte'
 import type {
     SvelteVirtualListDebugInfo,
     SvelteVirtualListProps,
+    SvelteVirtualListRangeInfo,
     SvelteVirtualListScrollAlign,
     SvelteVirtualListScrollOptions
 } from '$lib/types.js'
@@ -9,6 +10,7 @@ import type {
 export type {
     SvelteVirtualListDebugInfo,
     SvelteVirtualListProps,
+    SvelteVirtualListRangeInfo,
     SvelteVirtualListScrollAlign,
     SvelteVirtualListScrollOptions
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,26 @@ export type SvelteVirtualListProps<TItem = any> = {
      * @default true
      */
     hasMore?: boolean
+    /**
+     * Called whenever the rendered item range or the at-top/at-bottom state
+     * changes. Fires once after mount with the initial range. Use for
+     * impression tracking, URL sync, or scroll-position persistence.
+     */
+    onRangeChange?: (_range: SvelteVirtualListRangeInfo) => void
+}
+
+/**
+ * Snapshot of the rendered range and scroll edges, delivered via `onRangeChange`.
+ */
+export type SvelteVirtualListRangeInfo = {
+    /** Index of the first rendered item (includes buffer). */
+    start: number
+    /** Index one past the last rendered item (includes buffer). */
+    end: number
+    /** True when the viewport is scrolled to the very top. */
+    atTop: boolean
+    /** True when the viewport is scrolled to the very bottom. */
+    atBottom: boolean
 }
 
 /**

--- a/src/routes/tests/other/range-callback/+page.svelte
+++ b/src/routes/tests/other/range-callback/+page.svelte
@@ -17,16 +17,30 @@
     }))
 
     // Live tally of the public onRangeChange channel. `calls` counts every
-    // delivery so the dedupe behaviour is observable; `latest` is the most
-    // recent payload the component handed us.
+    // delivery so the dedupe behaviour is observable; `first` is the very
+    // first payload the component delivered (judged for the initial-range
+    // verdict); `latest` is the most recent one.
     let calls = $state(0)
+    let first = $state<SvelteVirtualListRangeInfo | null>(null)
     let latest = $state<SvelteVirtualListRangeInfo | null>(null)
     let running = $state(false)
+    let probeDone = $state(false)
 
     const handleRangeChange = (range: SvelteVirtualListRangeInfo) => {
         calls += 1
+        if (!first) first = range
         latest = range
     }
+
+    // Verdicts stay pending (null) only until the probe completes, then MUST
+    // resolve to pass or fail — a callback that never fired judges as fail
+    // (first/latest still null), never as endless "pending".
+    const initialPass = $derived(
+        probeDone ? first !== null && first.start === 0 && first.atTop === true : null
+    )
+    const finalPass = $derived(
+        probeDone ? latest !== null && latest.atBottom === true && latest.end === ITEM_COUNT : null
+    )
 
     const getViewport = (): HTMLElement | null =>
         document.querySelector('[data-testid="range-callback-list-viewport"]')
@@ -37,9 +51,17 @@
     // viewport all the way to the bottom so the spec can assert atBottom=1
     // and end=ITEM_COUNT arrive through the callback.
     const runProbe = async () => {
+        if (running) return
         const viewport = getViewport()
-        if (!viewport || running) return
+        if (!viewport) {
+            // No viewport rendered at all — judge immediately (both verdicts
+            // fail on whatever was or wasn't delivered) rather than hang
+            // forever in the pending state.
+            probeDone = true
+            return
+        }
         running = true
+        probeDone = false
 
         viewport.scrollTop = 0
         await settle(300)
@@ -47,6 +69,7 @@
         viewport.scrollTop = viewport.scrollHeight
         await settle(600)
 
+        probeDone = true
         running = false
     }
 
@@ -70,10 +93,12 @@
             noise — for impression tracking, URL sync, or scroll-position persistence.
         </p>
         <p>
-            <strong>How it's measured:</strong> the handler counts every delivery and records the
-            latest payload. The probe settles the list at the top, then scrolls the viewport to
-            <code>scrollHeight</code>. Identical payloads are de-duplicated, so
-            <code>calls</code> only grows on real range/edge changes.
+            <strong>How it's measured:</strong> the handler counts every delivery, keeps the first
+            payload, and records the latest one. The probe settles the list at the top, then scrolls
+            the viewport to <code>scrollHeight</code>. When the probe completes, both verdicts below
+            resolve to pass or fail — a callback that never fired reads as ✗, never as pending.
+            Identical payloads are de-duplicated, so <code>calls</code> only grows on real range/edge
+            changes.
         </p>
     </div>
 
@@ -88,6 +113,38 @@
             </span>
             <span class="expected">
                 after mount: start=0 atTop=1; after scroll-to-bottom: end={ITEM_COUNT} atBottom=1
+            </span>
+        </div>
+
+        <div class="stat" class:pass={initialPass === true} class:fail={initialPass === false}>
+            <span class="light"
+                >{initialPass === null ? (running ? '⟳' : '…') : initialPass ? '✓' : '✗'}</span
+            >
+            <span class="label">initial fire at the top</span>
+            <span class="value" data-testid="stat-initial">
+                start={first?.start ?? '—'} atTop={first ? b(first.atTop) : '—'} initialPass={initialPass ===
+                null
+                    ? '—'
+                    : b(initialPass)}
+            </span>
+            <span class="expected">
+                first payload ever delivered must be start=0 atTop=1; zero deliveries = fail
+            </span>
+        </div>
+
+        <div class="stat" class:pass={finalPass === true} class:fail={finalPass === false}>
+            <span class="light"
+                >{finalPass === null ? (running ? '⟳' : '…') : finalPass ? '✓' : '✗'}</span
+            >
+            <span class="label">bottom state after scroll</span>
+            <span class="value" data-testid="stat-final">
+                end={latest?.end ?? '—'} atBottom={latest ? b(latest.atBottom) : '—'} finalPass={finalPass ===
+                null
+                    ? '—'
+                    : b(finalPass)}
+            </span>
+            <span class="expected">
+                after the probe scrolls to the bottom: end={ITEM_COUNT} atBottom=1
             </span>
         </div>
 
@@ -168,8 +225,26 @@
         background: #eef2f7;
     }
 
+    .stat.pass {
+        background: #e9f7ee;
+        border-color: #b7e2c4;
+    }
+
+    .stat.fail {
+        background: #fdeaea;
+        border-color: #f2b8b8;
+    }
+
     .light {
         font-weight: 700;
+    }
+
+    .stat.pass .light {
+        color: #1a7f37;
+    }
+
+    .stat.fail .light {
+        color: #c62828;
     }
 
     .label {
@@ -179,6 +254,14 @@
     .value {
         font-variant-numeric: tabular-nums;
         font-weight: 600;
+    }
+
+    .stat.pass .value {
+        color: #1a7f37;
+    }
+
+    .stat.fail .value {
+        color: #c62828;
     }
 
     .expected {
@@ -202,10 +285,13 @@
         cursor: wait;
     }
 
+    /* The list's container is behind the items; if you see this red, the
+       viewport region is not covered by rendered items. Solid warning red
+       per the house rule — never gradients. */
     .test-container {
         width: 100%;
         height: 400px;
-        background: #f0f0f0;
+        background: #ffc2c2;
     }
 
     .fixed-item {

--- a/src/routes/tests/other/range-callback/+page.svelte
+++ b/src/routes/tests/other/range-callback/+page.svelte
@@ -1,0 +1,218 @@
+<script lang="ts">
+    import { onMount } from 'svelte'
+    import SvelteVirtualList from '$lib/index.js'
+    import type { SvelteVirtualListRangeInfo } from '$lib/types.js'
+
+    type Item = {
+        id: number
+        text: string
+    }
+
+    const ITEM_COUNT = 1000
+    const ITEM_HEIGHT_PX = 40
+
+    const items: Item[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    }))
+
+    // Live tally of the public onRangeChange channel. `calls` counts every
+    // delivery so the dedupe behaviour is observable; `latest` is the most
+    // recent payload the component handed us.
+    let calls = $state(0)
+    let latest = $state<SvelteVirtualListRangeInfo | null>(null)
+    let running = $state(false)
+
+    const handleRangeChange = (range: SvelteVirtualListRangeInfo) => {
+        calls += 1
+        latest = range
+    }
+
+    const getViewport = (): HTMLElement | null =>
+        document.querySelector('[data-testid="range-callback-list-viewport"]')
+
+    const settle = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+    // After mount the list settles at the top; the probe then scrolls the
+    // viewport all the way to the bottom so the spec can assert atBottom=1
+    // and end=ITEM_COUNT arrive through the callback.
+    const runProbe = async () => {
+        const viewport = getViewport()
+        if (!viewport || running) return
+        running = true
+
+        viewport.scrollTop = 0
+        await settle(300)
+
+        viewport.scrollTop = viewport.scrollHeight
+        await settle(600)
+
+        running = false
+    }
+
+    onMount(() => {
+        const timer = setTimeout(runProbe, 500)
+        return () => clearTimeout(timer)
+    })
+
+    const b = (v: boolean) => (v ? 1 : 0)
+</script>
+
+<div class="page">
+    <h1>onRangeChange — public visible-range / scroll-edge callback</h1>
+
+    <div class="description">
+        <p>
+            <strong>What:</strong> the list exposes a first-class
+            <code>onRangeChange</code> prop that fires whenever the rendered range or the
+            at-top/at-bottom state changes. It delivers a trimmed
+            <code>{'{ start, end, atTop, atBottom }'}</code> payload — no debug gating and no console
+            noise — for impression tracking, URL sync, or scroll-position persistence.
+        </p>
+        <p>
+            <strong>How it's measured:</strong> the handler counts every delivery and records the
+            latest payload. The probe settles the list at the top, then scrolls the viewport to
+            <code>scrollHeight</code>. Identical payloads are de-duplicated, so
+            <code>calls</code> only grows on real range/edge changes.
+        </p>
+    </div>
+
+    <div class="stats" data-testid="range-callback-stats">
+        <div class="stat" class:running>
+            <span class="light">{running ? '⟳' : latest ? '✓' : '…'}</span>
+            <span class="label">range callback</span>
+            <span class="value" data-testid="stat-range">
+                calls={calls} start={latest?.start ?? '—'} end={latest?.end ?? '—'} atTop={latest
+                    ? b(latest.atTop)
+                    : '—'} atBottom={latest ? b(latest.atBottom) : '—'}
+            </span>
+            <span class="expected">
+                after mount: start=0 atTop=1; after scroll-to-bottom: end={ITEM_COUNT} atBottom=1
+            </span>
+        </div>
+
+        <button class="remeasure" onclick={runProbe} disabled={running}>
+            {running ? 'probing…' : 'Re-run probe'}
+        </button>
+    </div>
+
+    <div class="test-container">
+        <SvelteVirtualList
+            defaultEstimatedItemHeight={ITEM_HEIGHT_PX}
+            {items}
+            testId="range-callback-list"
+            onRangeChange={handleRangeChange}
+        >
+            {#snippet renderItem(item)}
+                <div class="fixed-item" style="height: {ITEM_HEIGHT_PX}px;">
+                    {item.text}
+                </div>
+            {/snippet}
+        </SvelteVirtualList>
+    </div>
+</div>
+
+<style>
+    .page {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 16px;
+        font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
+    }
+
+    h1 {
+        font-size: 18px;
+        margin: 0 0 12px;
+    }
+
+    .description {
+        font-size: 13px;
+        line-height: 1.5;
+        color: #333;
+        background: #fafafa;
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 4px 14px;
+        margin-bottom: 12px;
+    }
+
+    .description code {
+        background: #eef2f7;
+        padding: 1px 4px;
+        border-radius: 3px;
+    }
+
+    .stats {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 12px;
+        font-size: 13px;
+    }
+
+    .stat {
+        display: grid;
+        grid-template-columns: 22px 160px minmax(320px, auto) 1fr;
+        gap: 8px;
+        align-items: baseline;
+        padding: 6px 10px;
+        border-radius: 6px;
+        border: 1px solid #e5e5e5;
+        background: #f6f6f6;
+    }
+
+    .stat.running {
+        background: #eef2f7;
+    }
+
+    .light {
+        font-weight: 700;
+    }
+
+    .label {
+        font-weight: 600;
+    }
+
+    .value {
+        font-variant-numeric: tabular-nums;
+        font-weight: 600;
+    }
+
+    .expected {
+        color: #777;
+        font-size: 12px;
+    }
+
+    .remeasure {
+        align-self: flex-start;
+        margin-top: 4px;
+        padding: 6px 14px;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 13px;
+    }
+
+    .remeasure:disabled {
+        opacity: 0.6;
+        cursor: wait;
+    }
+
+    .test-container {
+        width: 100%;
+        height: 400px;
+        background: #f0f0f0;
+    }
+
+    .fixed-item {
+        box-sizing: border-box;
+        padding: 8px 12px;
+        border-bottom: 1px solid #eee;
+        background: #fff;
+        font-size: 14px;
+    }
+</style>

--- a/tests/other/range-callback.spec.ts
+++ b/tests/other/range-callback.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+import { readStats, stat } from '../../src/lib/test/utils/statsLine.js'
+
+/**
+ * onRangeChange — public visible-range / scroll-edge callback
+ *
+ * The list exposes a first-class onRangeChange prop that fires whenever the
+ * rendered range or the at-top/at-bottom state changes, delivering a trimmed
+ * { start, end, atTop, atBottom } payload (no debug gating, no console
+ * noise). The fixture at /tests/other/range-callback counts every delivery
+ * and records the latest payload, then a probe scrolls the viewport to the
+ * bottom. These specs assert on the fixture's own stats.
+ */
+
+test.describe('onRangeChange - public range callback', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/other/range-callback', { waitUntil: 'domcontentloaded' })
+        // Require a digit: the pre-fire placeholder renders dashes for start.
+        await expect(page.locator(stat('range'))).toContainText(/calls=\d/, {
+            timeout: 15000
+        })
+        // Wait for the initial fire to populate a real range (start=0 atTop=1).
+        await expect(page.locator(stat('range'))).toContainText(/start=\d/, {
+            timeout: 15000
+        })
+    })
+
+    test('delivers the initial range at the top, then bottom state after scrolling', async ({
+        page
+    }) => {
+        // Initial fire: rendered range starts at 0 and the viewport is at top.
+        const initial = await readStats(page, 'range')
+        expect(initial.start).toBe(0)
+        expect(initial.atTop).toBe(1)
+        const initialCalls = initial.calls
+
+        // The probe scrolls the viewport to the bottom; wait for atBottom=1.
+        await expect(page.locator(stat('range'))).toContainText(/atBottom=1/, {
+            timeout: 15000
+        })
+
+        const scrolled = await readStats(page, 'range')
+        expect(scrolled.atBottom).toBe(1)
+        expect(scrolled.end).toBe(1000)
+        expect(scrolled.calls).toBeGreaterThan(initialCalls)
+    })
+})

--- a/tests/other/range-callback.spec.ts
+++ b/tests/other/range-callback.spec.ts
@@ -46,12 +46,13 @@ test.describe('onRangeChange - public range callback', () => {
     })
 
     test('the page judges its own verdicts green once the probe completes', async ({ page }) => {
-        // Verdicts resolve only when the probe finishes — require a digit,
-        // never the pending placeholder dash.
-        await expect(page.locator(stat('final'))).toContainText(/finalPass=\d/, {
+        // Wait for the pass tokens directly (same pattern as the atBottom=1
+        // wait above): a bare digit would also match a transiently failing
+        // verdict (…=0) and let the hard assertions below flake.
+        await expect(page.locator(stat('final'))).toContainText(/finalPass=1/, {
             timeout: 15000
         })
-        await expect(page.locator(stat('initial'))).toContainText(/initialPass=\d/, {
+        await expect(page.locator(stat('initial'))).toContainText(/initialPass=1/, {
             timeout: 15000
         })
 

--- a/tests/other/range-callback.spec.ts
+++ b/tests/other/range-callback.spec.ts
@@ -44,4 +44,27 @@ test.describe('onRangeChange - public range callback', () => {
         expect(scrolled.end).toBe(1000)
         expect(scrolled.calls).toBeGreaterThan(initialCalls)
     })
+
+    test('the page judges its own verdicts green once the probe completes', async ({ page }) => {
+        // Verdicts resolve only when the probe finishes — require a digit,
+        // never the pending placeholder dash.
+        await expect(page.locator(stat('final'))).toContainText(/finalPass=\d/, {
+            timeout: 15000
+        })
+        await expect(page.locator(stat('initial'))).toContainText(/initialPass=\d/, {
+            timeout: 15000
+        })
+
+        // First delivery was the top-of-list range.
+        const initial = await readStats(page, 'initial')
+        expect(initial.start).toBe(0)
+        expect(initial.atTop).toBe(1)
+        expect(initial.initialPass).toBe(1)
+
+        // Latest delivery reflects the scrolled-to-bottom state.
+        const final = await readStats(page, 'final')
+        expect(final.end).toBe(1000)
+        expect(final.atBottom).toBe(1)
+        expect(final.finalPass).toBe(1)
+    })
 })


### PR DESCRIPTION
## Summary

Adds a first-class `onRangeChange` prop delivering a trimmed `{ start, end, atTop, atBottom }` payload whenever the rendered range or scroll-edge state changes. The component already computed all of this, but the only delivery channel was `debugFunction` behind `debug=true` — consumers doing impression tracking, URL sync, read receipts, or scroll-position persistence had to abuse debug mode in production. Every comparable library (TanStack Virtual, react-virtuoso, virtua, react-window, svelte-tiny-virtual-list) ships this; now we do too.

Deliveries are deduped (identical payloads never re-fire), edge math intentionally mirrors the debug channel's so the two can never disagree, and the effect-based delivery means SSR never invokes the callback. Executed from plan `.agents/.plans/perf-parity/002` with independent guard review: all done criteria reproduced (312 unit / 355 e2e across 5 engines / trunk clean).

## Changes

- ✨ `onRangeChange?: (range: SvelteVirtualListRangeInfo) => void` prop + exported `SvelteVirtualListRangeInfo` type (`start`/`end` are buffer-inclusive, documented as such)
- ✨ Deduped `$effect` delivery — fires once after mount with the initial range, then only on genuine range/edge changes; fresh payload object per call
- 🧪 4 unit tests: initial-fire payload values, dedupe across unrelated re-renders, exact payload key-set/types on every call, absent-prop mounts clean
- 🧪 Self-judging fixture at `/tests/other/range-callback` (house red/green style: initial-fire and bottom-state verdict rows that resolve pass/fail on every terminal path — a dead callback shows ✗, never endless pending — over a warning-red backdrop) + Playwright spec asserting both the callback stats and the page's own verdicts
- 📚 README: props row + "Observing the visible range" usage section

## Commits

- [`9e403fc`](https://github.com/humanspeak/svelte-virtual-list/commit/9e403fc70ec84c99633315384bd0b2be6a7ab952) feat(virtual-list): add public onRangeChange callback
- [`d2633bd`](https://github.com/humanspeak/svelte-virtual-list/commit/d2633bd65fe1d7e7bcb74e172475a9a96bc1733c) test(virtual-list): make range-callback fixture self-judging (red/green)

## Notes for review

- Forks from the same base as #423; both PRs edit different regions of `SvelteVirtualList.svelte` — whichever merges second needs a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
