### PR TITLE
feat(virtual-list): align center and scrollToOffset for programmatic scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,14 @@ Scroll to any item in the list using the `scroll` method. Useful for jump-to-ite
     function goToItem5000() {
         listRef.scroll({ index: 5000, smoothScroll: true, align: 'auto' })
     }
+
+    function restoreScrollPosition() {
+        listRef.scrollToOffset({ offset: 12345, smoothScroll: false })
+    }
 </script>
 
 <button onclick={goToItem5000}> Scroll to item 5000 </button>
+<button onclick={restoreScrollPosition}> Restore scroll position </button>
 <SvelteVirtualList {items} bind:this={listRef}>
     {#snippet renderItem(item)}
         <div>{item.text}</div>
@@ -133,12 +138,12 @@ Scroll to any item in the list using the `scroll` method. Useful for jump-to-ite
 
 ### scroll() Options
 
-| Option                | Type                                       | Default  | Description                             |
-| --------------------- | ------------------------------------------ | -------- | --------------------------------------- |
-| `index`               | `number`                                   | Required | The item index to scroll to (0-based)   |
-| `smoothScroll`        | `boolean`                                  | `true`   | Use smooth scrolling animation          |
-| `shouldThrowOnBounds` | `boolean`                                  | `true`   | Throw if index is out of bounds         |
-| `align`               | `'auto' \| 'top' \| 'bottom' \| 'nearest'` | `'auto'` | Where to align the item in the viewport |
+| Option                | Type                                                   | Default  | Description                             |
+| --------------------- | ------------------------------------------------------ | -------- | --------------------------------------- |
+| `index`               | `number`                                               | Required | The item index to scroll to (0-based)   |
+| `smoothScroll`        | `boolean`                                              | `true`   | Use smooth scrolling animation          |
+| `shouldThrowOnBounds` | `boolean`                                              | `true`   | Throw if index is out of bounds         |
+| `align`               | `'auto' \| 'top' \| 'bottom' \| 'nearest' \| 'center'` | `'auto'` | Where to align the item in the viewport |
 
 Alignment options:
 
@@ -146,6 +151,16 @@ Alignment options:
 - `'top'` - Always align to the top
 - `'bottom'` - Always align to the bottom
 - `'nearest'` - Scroll as little as possible to bring the item into view
+- `'center'` - Center the item in the viewport, clamped at the list edges
+
+### scrollToOffset() Options
+
+Use `scrollToOffset({ offset, smoothScroll })` to scroll to a raw pixel offset, such as restoring a persisted scroll position after navigation. The returned promise resolves after scrolling has visually finished.
+
+| Option         | Type      | Default  | Description                          |
+| -------------- | --------- | -------- | ------------------------------------ |
+| `offset`       | `number`  | Required | Raw vertical scroll offset in pixels |
+| `smoothScroll` | `boolean` | `true`   | Use smooth scrolling animation       |
 
 ## Infinite Scroll
 

--- a/docs/src/lib/examples/MethodsExample.svelte
+++ b/docs/src/lib/examples/MethodsExample.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import VirtualList from '@humanspeak/svelte-virtual-list'
 
-    type Align = 'auto' | 'top' | 'bottom' | 'nearest'
+    type Align = 'auto' | 'top' | 'bottom' | 'nearest' | 'center'
 
     type ListRef = {
         scroll: (_options: {
@@ -89,6 +89,7 @@
                 <option value="top">top</option>
                 <option value="bottom">bottom</option>
                 <option value="nearest">nearest</option>
+                <option value="center">center</option>
             </select>
         </label>
         <label class="check">
@@ -97,7 +98,7 @@
         </label>
         <button type="button" class="run" onclick={() => scrollTo()}>run</button>
         <button type="button" onclick={() => scrollTo(0, 'top')}>first</button>
-        <button type="button" onclick={() => scrollTo(500, 'auto')}>middle</button>
+        <button type="button" onclick={() => scrollTo(500, 'center')}>middle</button>
         <button type="button" onclick={() => scrollTo(items.length - 1, 'bottom')}>last</button>
         <div class="status">● ready</div>
     </div>

--- a/docs/src/lib/examples/ScrollToItemExample.svelte
+++ b/docs/src/lib/examples/ScrollToItemExample.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import VirtualList from '@humanspeak/svelte-virtual-list'
 
-    type Align = 'auto' | 'top' | 'bottom' | 'nearest'
+    type Align = 'auto' | 'top' | 'bottom' | 'nearest' | 'center'
 
     type ListRef = {
         scroll: (_options: { index: number; smoothScroll?: boolean; align?: Align }) => void
@@ -76,11 +76,12 @@
                 <option value="top">top</option>
                 <option value="bottom">bottom</option>
                 <option value="nearest">nearest</option>
+                <option value="center">center</option>
             </select>
         </label>
         <button type="button" class="run" onclick={() => scrollTo()}>run</button>
         <button type="button" onclick={() => scrollTo(0, 'top')}>first</button>
-        <button type="button" onclick={() => scrollTo(5000, 'auto')}>middle</button>
+        <button type="button" onclick={() => scrollTo(5000, 'center')}>middle</button>
         <button type="button" onclick={() => scrollTo(items.length - 1, 'bottom')}>last</button>
         <div class="status">● ready</div>
     </div>

--- a/docs/src/lib/examples/scroll-to-item/demos/Default.svelte
+++ b/docs/src/lib/examples/scroll-to-item/demos/Default.svelte
@@ -5,11 +5,11 @@
         scroll: (_options: {
             index: number
             smoothScroll?: boolean
-            align?: 'auto' | 'top' | 'bottom' | 'nearest'
+            align?: 'auto' | 'top' | 'bottom' | 'nearest' | 'center'
         }) => void
     }
 
-    type Align = 'auto' | 'top' | 'bottom' | 'nearest'
+    type Align = 'auto' | 'top' | 'bottom' | 'nearest' | 'center'
 
     let listRef: ListRef | undefined = $state(undefined)
     let targetIndex = $state(5000)
@@ -80,11 +80,12 @@
                 <option value="top">top</option>
                 <option value="bottom">bottom</option>
                 <option value="nearest">nearest</option>
+                <option value="center">center</option>
             </select>
         </label>
         <button type="button" class="run" onclick={() => scrollToTarget()}>run</button>
         <button type="button" onclick={() => scrollToTarget(0, 'top')}>first</button>
-        <button type="button" onclick={() => scrollToTarget(5000, 'auto')}>middle</button>
+        <button type="button" onclick={() => scrollToTarget(5000, 'center')}>middle</button>
         <button type="button" onclick={() => scrollToTarget(9999, 'bottom')}>last</button>
     </div>
     <div class="demo-frame" bind:this={demoFrame}>

--- a/docs/src/routes/docs/api/methods/+page.svx
+++ b/docs/src/routes/docs/api/methods/+page.svx
@@ -66,7 +66,7 @@ settles); for an instant scroll it resolves after the DOM updates.
 |----------|------|---------|-------------|
 | `index` | `number` | required | Target item index |
 | `smoothScroll` | `boolean` | `true` | Use smooth scroll animation |
-| `align` | `'auto' \| 'top' \| 'bottom' \| 'nearest'` | `'auto'` | Alignment of target item |
+| `align` | `'auto' \| 'top' \| 'bottom' \| 'nearest' \| 'center'` | `'auto'` | Alignment of target item |
 | `shouldThrowOnBounds` | `boolean` | `true` | Throw error if index out of bounds |
 
 ### Examples
@@ -86,6 +86,11 @@ await listRef.scroll({ index: 0, align: 'top' })
 await listRef.scroll({ index: items.length - 1, align: 'bottom' })
 ```
 
+**Center an item in the viewport:**
+```typescript
+await listRef.scroll({ index: 500, align: 'center' })
+```
+
 **Instant scroll (no animation):**
 ```typescript
 await listRef.scroll({ index: 500, smoothScroll: false })
@@ -99,6 +104,41 @@ await listRef.scroll({ index: 500, smoothScroll: false })
 | `'top'` | Align item to top of viewport |
 | `'bottom'` | Align item to bottom of viewport |
 | `'nearest'` | Scroll to nearest edge if not visible |
+| `'center'` | Center the item vertically in the viewport, clamped at the list edges |
+
+## scrollToOffset()
+
+Scroll to a raw pixel offset instead of an item index. Complements `scroll()` and is ideal for restoring a persisted scroll position after navigation.
+
+### Signature
+
+```typescript
+scrollToOffset(options: {
+    offset: number
+    smoothScroll?: boolean
+}): Promise<void>
+```
+
+The `offset` is clamped to the list's valid scroll range, so values past the end settle at the bottom. The returned promise resolves once the scroll has visually finished.
+
+### Options
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `offset` | `number` | required | Raw vertical scroll offset in pixels |
+| `smoothScroll` | `boolean` | `true` | Use smooth scroll animation |
+
+### Examples
+
+**Restore a saved scroll position instantly:**
+```typescript
+await listRef.scrollToOffset({ offset: 12345, smoothScroll: false })
+```
+
+**Smoothly scroll to a pixel offset:**
+```typescript
+await listRef.scrollToOffset({ offset: 2000 })
+```
 
 ## scrollToTop()
 

--- a/docs/src/routes/docs/api/types/+page.svx
+++ b/docs/src/routes/docs/api/types/+page.svx
@@ -68,7 +68,7 @@ interface SvelteVirtualListScrollOptions {
 Alignment options for programmatic scrolling.
 
 ```typescript
-type SvelteVirtualListScrollAlign = 'auto' | 'top' | 'bottom' | 'nearest'
+type SvelteVirtualListScrollAlign = 'auto' | 'top' | 'bottom' | 'nearest' | 'center'
 ```
 
 ## SvelteVirtualListDebugInfo

--- a/docs/src/routes/docs/scroll-methods/+page.svx
+++ b/docs/src/routes/docs/scroll-methods/+page.svx
@@ -75,8 +75,8 @@ scroll(options: {
     index: number
     smoothScroll?: boolean
     shouldThrowOnBounds?: boolean
-    align?: 'auto' | 'top' | 'bottom' | 'nearest'
-})
+    align?: 'auto' | 'top' | 'bottom' | 'nearest' | 'center'
+}): Promise<void>
 ```
 
 ### Options
@@ -94,6 +94,7 @@ scroll(options: {
 - **`'top'`** - Always align the item to the top of the viewport.
 - **`'bottom'`** - Always align the item to the bottom of the viewport.
 - **`'nearest'`** - Scroll as little as possible to bring the item into view (like native `scrollIntoView({ block: 'nearest' })`).
+- **`'center'`** - Center the item vertically in the viewport, clamped at the list edges. Great for focusing a search result or highlighted item so it lands in the middle of the view.
 
 ## Examples
 
@@ -129,6 +130,61 @@ scroll(options: {
 </button>
 ```
 
+### Center the item in the viewport
+
+```svelte
+<button onclick={() => listRef.scroll({ index: 500, align: 'center' })}>
+    Scroll to item 500 (centered)
+</button>
+```
+
+## scrollToOffset(options)
+
+Scrolls the viewport to a raw pixel offset instead of an item index. This complements `scroll()` (which is index-based) and is ideal for restoring a persisted scroll position after navigation.
+
+```typescript
+scrollToOffset(options: {
+    offset: number
+    smoothScroll?: boolean
+}): Promise<void>
+```
+
+The offset is clamped to the list's valid scroll range, so values beyond the end simply settle at the bottom. The returned promise resolves once scrolling has visually finished.
+
+### Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `offset` | `number` | Required | Raw vertical scroll offset in pixels |
+| `smoothScroll` | `boolean` | `true` | Use smooth scrolling animation |
+
+### Example
+
+```svelte
+<script lang="ts">
+    import VirtualList from '@humanspeak/svelte-virtual-list'
+
+    let listRef
+
+    // e.g. a value read back from sessionStorage
+    const savedOffset = 12345
+
+    function restoreScrollPosition() {
+        listRef.scrollToOffset({ offset: savedOffset, smoothScroll: false })
+    }
+</script>
+
+<button onclick={restoreScrollPosition}>
+    Restore scroll position
+</button>
+
+<VirtualList {items} bind:this={listRef}>
+    {#snippet renderItem(item)}
+        <div>{item.text}</div>
+    {/snippet}
+</VirtualList>
+```
+
 ## TypeScript
 
 For full type safety, you can type the ref:
@@ -139,8 +195,12 @@ type ListRef = {
         index: number
         smoothScroll?: boolean
         shouldThrowOnBounds?: boolean
-        align?: 'auto' | 'top' | 'bottom' | 'nearest'
-    }) => void
+        align?: 'auto' | 'top' | 'bottom' | 'nearest' | 'center'
+    }) => Promise<void>
+    scrollToOffset: (options: {
+        offset: number
+        smoothScroll?: boolean
+    }) => Promise<void>
 }
 
 let listRef: ListRef | undefined = $state(undefined)

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -830,6 +830,52 @@
         return scroll({ index, smoothScroll, shouldThrowOnBounds })
     }
 
+    const executeScrollToTarget = (
+        scrollTarget: number,
+        smoothScroll: boolean,
+        signal: AbortSignal,
+        resolve: () => void,
+        reject: (reason?: unknown) => void
+    ) => {
+        // Suspend anchor preservation while this scroll animates — a
+        // scrollTop write would cancel the smooth scroll mid-flight.
+        programmaticScrollDepth++
+
+        heightManager.viewport.scrollTo({
+            top: scrollTarget,
+            behavior: smoothScroll ? 'smooth' : 'auto'
+        })
+
+        // Update scrollTop state in next frame to avoid synchronous re-renders
+        requestAnimationFrame(() => {
+            // Superseded by a newer programmatic scroll or keyboard input: don't
+            // clobber the newer position with this scroll's stale target.
+            if (signal.aborted) return
+            heightManager.scrollTop = scrollTarget
+            if (INTERNAL_DEBUG && heightManager.viewportElement) {
+                const domMax = Math.max(
+                    0,
+                    heightManager.viewport.scrollHeight - heightManager.viewport.clientHeight
+                )
+                console.info('[SVL] scroll-after-call', {
+                    scrollTop: heightManager.scrollTop,
+                    domMaxScrollTop: domMax
+                })
+            }
+        })
+
+        // Resolve only once the scroll has visually finished AND the virtual
+        // list has re-rendered for the new position.
+        waitForScrollEnd(heightManager.viewport, scrollTarget, smoothScroll, signal)
+            .then(async () => {
+                await tick()
+                resolve()
+            }, reject)
+            .finally(() => {
+                programmaticScrollDepth = Math.max(0, programmaticScrollDepth - 1)
+            })
+    }
+
     /**
      * Scrolls the virtual list to the item at the given index using a type-based options approach.
      *
@@ -923,7 +969,8 @@
                 firstVisibleIndex,
                 lastVisibleIndex,
                 heightCache: heightManager.getHeightCache(),
-                blockSums: heightManager.getBlockSums()
+                blockSums: heightManager.getBlockSums(),
+                maxScrollTop: currentMaxScrollTop()
             })
 
             // Handle early return for 'nearest' alignment when item is already visible
@@ -948,43 +995,7 @@
                 })
             }
 
-            // Suspend anchor preservation while this scroll animates — a
-            // scrollTop write would cancel the smooth scroll mid-flight.
-            programmaticScrollDepth++
-
-            heightManager.viewport.scrollTo({
-                top: scrollTarget,
-                behavior: smoothScroll ? 'smooth' : 'auto'
-            })
-
-            // Update scrollTop state in next frame to avoid synchronous re-renders
-            requestAnimationFrame(() => {
-                // Superseded (newer scroll() or keyboard input): don't clobber
-                // the newer position with this scroll's stale target.
-                if (signal.aborted) return
-                heightManager.scrollTop = scrollTarget
-                if (INTERNAL_DEBUG && heightManager.viewportElement) {
-                    const domMax = Math.max(
-                        0,
-                        heightManager.viewport.scrollHeight - heightManager.viewport.clientHeight
-                    )
-                    console.info('[SVL] scroll-after-call', {
-                        scrollTop: heightManager.scrollTop,
-                        domMaxScrollTop: domMax
-                    })
-                }
-            })
-
-            // Resolve only once the scroll has visually finished AND the virtual
-            // list has re-rendered for the new position.
-            waitForScrollEnd(heightManager.viewport, scrollTarget, smoothScroll ?? true, signal)
-                .then(async () => {
-                    await tick()
-                    resolve()
-                }, reject)
-                .finally(() => {
-                    programmaticScrollDepth = Math.max(0, programmaticScrollDepth - 1)
-                })
+            executeScrollToTarget(scrollTarget, smoothScroll ?? true, signal, resolve, reject)
         })
     }
 

--- a/src/lib/SvelteVirtualList.svelte
+++ b/src/lib/SvelteVirtualList.svelte
@@ -835,7 +835,7 @@
         smoothScroll: boolean,
         signal: AbortSignal,
         resolve: () => void,
-        reject: (reason?: unknown) => void
+        reject: (_reason?: unknown) => void
     ) => {
         // Suspend anchor preservation while this scroll animates — a
         // scrollTop write would cancel the smooth scroll mid-flight.
@@ -996,6 +996,38 @@
             }
 
             executeScrollToTarget(scrollTarget, smoothScroll ?? true, signal, resolve, reject)
+        })
+    }
+
+    /**
+     * Scrolls the viewport to a raw pixel offset. Complements {@link scroll}
+     * (index-based): use this to restore a persisted scroll position.
+     *
+     * @returns Promise that resolves when scrolling has visually finished.
+     */
+    export const scrollToOffset = (options: {
+        offset: number
+        smoothScroll?: boolean
+    }): Promise<void> => {
+        const { offset, smoothScroll = true } = options
+        scrollAbortController?.abort()
+        const abortController = new AbortController()
+        scrollAbortController = abortController
+        const { signal } = abortController
+
+        return new Promise<void>((resolve, reject) => {
+            if (!heightManager.viewportElement) {
+                tick().then(() => {
+                    if (signal.aborted || !heightManager.viewportElement) {
+                        resolve()
+                        return
+                    }
+                    scrollToOffset({ offset, smoothScroll }).then(resolve, reject)
+                })
+                return
+            }
+            const target = Math.round(clampValue(offset, 0, currentMaxScrollTop()))
+            executeScrollToTarget(target, smoothScroll, signal, resolve, reject)
         })
     }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -126,7 +126,7 @@ export type SvelteVirtualListDebugInfo = {
 /**
  * Alignment options for programmatic scrolling.
  */
-export type SvelteVirtualListScrollAlign = 'auto' | 'top' | 'bottom' | 'nearest'
+export type SvelteVirtualListScrollAlign = 'auto' | 'top' | 'bottom' | 'nearest' | 'center'
 
 /**
  * Options for scrolling to a specific index in the virtual list.
@@ -138,7 +138,7 @@ export interface SvelteVirtualListScrollOptions {
     smoothScroll?: boolean
     /** Whether to throw an error if the index is out of bounds. Default: true */
     shouldThrowOnBounds?: boolean
-    /** Alignment for the scrolled item: 'auto', 'top', or 'bottom'. Default: 'auto' */
+    /** Alignment for the scrolled item: 'auto', 'top', 'bottom', 'nearest', or 'center'. Default: 'auto' */
     align?: SvelteVirtualListScrollAlign
 }
 

--- a/src/lib/utils/scrollCalculation.test.ts
+++ b/src/lib/utils/scrollCalculation.test.ts
@@ -271,6 +271,76 @@ describe('calculateScrollTarget', () => {
     }
 
     describe('topToBottom mode', () => {
+        describe('center alignment', () => {
+            it('centers the target item in the viewport for align center', () => {
+                const target = calculateScrollTarget({
+                    align: 'center',
+                    targetIndex: 50,
+                    itemsLength: 100,
+                    calculatedItemHeight: 40,
+                    height: 400,
+                    scrollTop: 0,
+                    firstVisibleIndex: 0,
+                    lastVisibleIndex: 10,
+                    heightCache: {}
+                })
+                // itemTop = 50*40 = 2000, itemHeight = 40, viewport = 400
+                // centered: 2000 - (400 - 40) / 2 = 1820
+                expect(target).toBe(1820)
+            })
+
+            it('centers an item taller than the viewport using the same formula', () => {
+                const target = calculateScrollTarget({
+                    ...baseParams,
+                    align: 'center',
+                    targetIndex: 2,
+                    calculatedItemHeight: 40,
+                    height: 400,
+                    heightCache: { 2: 600 }
+                })
+
+                expect(target).toBe(180)
+            })
+
+            it('clamps a centered target near the start to zero', () => {
+                const target = calculateScrollTarget({
+                    ...baseParams,
+                    align: 'center',
+                    targetIndex: 0,
+                    calculatedItemHeight: 40,
+                    height: 400
+                })
+
+                expect(target).toBe(0)
+            })
+
+            it('clamps a centered target near the end to maxScrollTop', () => {
+                const target = calculateScrollTarget({
+                    ...baseParams,
+                    align: 'center',
+                    targetIndex: 99,
+                    calculatedItemHeight: 40,
+                    height: 400,
+                    maxScrollTop: 3600
+                })
+
+                expect(target).toBe(3600)
+            })
+
+            it('centers using non-uniform measured heights', () => {
+                const target = calculateScrollTarget({
+                    ...baseParams,
+                    align: 'center',
+                    targetIndex: 2,
+                    calculatedItemHeight: 40,
+                    height: 200,
+                    heightCache: { 0: 20, 1: 60, 2: 100 }
+                })
+
+                expect(target).toBe(30)
+            })
+        })
+
         describe('auto alignment', () => {
             it('should scroll to top when item is above viewport', () => {
                 const params = {

--- a/src/lib/utils/scrollCalculation.ts
+++ b/src/lib/utils/scrollCalculation.ts
@@ -202,12 +202,14 @@ export interface ScrollTargetParams {
     heightCache: Record<number, number>
     /** Optional precomputed block sums for O(blockSize) offset lookup (see buildBlockSums). */
     blockSums?: number[]
+    /** Optional maximum scroll position used to clamp centered targets. */
+    maxScrollTop?: number
 }
 
 /**
  * Calculates the target scroll position for scrolling to a specific item index.
  *
- * This function handles different alignment options (auto, top, bottom, nearest)
+ * This function handles different alignment options (auto, top, bottom, nearest, center)
  * and calculates the optimal scroll position based on the current viewport state.
  *
  * @param params - Parameters for scroll target calculation
@@ -242,7 +244,8 @@ export const calculateScrollTarget = (params: ScrollTargetParams): number | null
         firstVisibleIndex,
         lastVisibleIndex,
         heightCache,
-        blockSums
+        blockSums,
+        maxScrollTop
     } = params
 
     return calculateTopToBottomScrollTarget({
@@ -254,7 +257,8 @@ export const calculateScrollTarget = (params: ScrollTargetParams): number | null
         firstVisibleIndex,
         lastVisibleIndex,
         heightCache,
-        blockSums
+        blockSums,
+        maxScrollTop
     })
 }
 
@@ -282,6 +286,8 @@ interface TopToBottomScrollParams {
     heightCache: Record<number, number>
     /** Optional precomputed block sums for O(blockSize) offset lookup (see buildBlockSums). */
     blockSums?: number[]
+    /** Optional maximum scroll position used to clamp centered targets. */
+    maxScrollTop?: number
 }
 
 /**
@@ -305,7 +311,8 @@ const calculateTopToBottomScrollTarget = (params: TopToBottomScrollParams): numb
         firstVisibleIndex,
         lastVisibleIndex,
         heightCache,
-        blockSums
+        blockSums,
+        maxScrollTop
     } = params
 
     // Calculate item boundaries
@@ -334,6 +341,12 @@ const calculateTopToBottomScrollTarget = (params: TopToBottomScrollParams): numb
             // Item is visible - align to nearest edge (always returns a value)
             return alignVisibleToNearestEdge(itemTop, itemBottom, scrollTop, height)
         }
+    }
+
+    if (align === 'center') {
+        const itemHeight = itemBottom - itemTop
+        const target = itemTop - (height - itemHeight) / 2
+        return Math.round(clampValue(target, 0, maxScrollTop ?? Infinity))
     }
 
     if (align === 'top' || align === 'bottom' || align === 'nearest') {

--- a/src/routes/tests/issues/issue-165/+page.svelte
+++ b/src/routes/tests/issues/issue-165/+page.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+    import { onMount } from 'svelte'
+    import SvelteVirtualList from '$lib/index.js'
+
+    type Item = {
+        id: number
+        text: string
+    }
+
+    const ITEM_COUNT = 1_000
+    const ITEM_HEIGHT_PX = 40
+    const VIEWPORT_HEIGHT_PX = 400
+    const CENTER_INDEX = 500
+    const RESTORE_OFFSET_PX = 12_345
+
+    const items: Item[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
+        id: i,
+        text: `Item ${i}`
+    }))
+
+    let listRef: SvelteVirtualList<Item>
+    let centerDeltaPx = $state<number | null>(null)
+    let scrollTopPx = $state<number | null>(null)
+    let running = $state(false)
+
+    const centerPass = $derived(centerDeltaPx !== null && centerDeltaPx <= 2)
+    const offsetPass = $derived(
+        scrollTopPx !== null && Math.abs(scrollTopPx - RESTORE_OFFSET_PX) <= 2
+    )
+
+    const getViewport = (): HTMLElement | null =>
+        document.querySelector('[data-testid="issue-165-list-viewport"]')
+
+    const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    const runProbes = async () => {
+        const viewport = getViewport()
+        if (!viewport || !listRef || running) return
+        running = true
+        centerDeltaPx = null
+        scrollTopPx = null
+
+        await listRef.scroll({ index: CENTER_INDEX, align: 'center', smoothScroll: false })
+        await nextFrame()
+
+        const target = viewport.querySelector(`[data-testid="issue-165-item-${CENTER_INDEX}"]`)
+        if (target) {
+            const viewportRect = viewport.getBoundingClientRect()
+            const targetRect = target.getBoundingClientRect()
+            const viewportCenter = (viewportRect.top + viewportRect.bottom) / 2
+            const targetCenter = (targetRect.top + targetRect.bottom) / 2
+            centerDeltaPx = Math.round(Math.abs(targetCenter - viewportCenter))
+        } else {
+            // Keep a missing target visibly red and machine-readable.
+            centerDeltaPx = 999_999
+        }
+
+        await listRef.scrollToOffset({ offset: RESTORE_OFFSET_PX, smoothScroll: false })
+        await nextFrame()
+        scrollTopPx = Math.round(viewport.scrollTop)
+        running = false
+    }
+
+    onMount(() => {
+        const timer = setTimeout(runProbes, 500)
+        return () => clearTimeout(timer)
+    })
+</script>
+
+<div class="page">
+    <h1>Issue #165 — center-aligned programmatic scrolling</h1>
+
+    <div class="description">
+        <p>
+            <strong>What:</strong> issue #165 asked for top, center, or bottom alignment when
+            scrolling to an item. Before the fix, <code>align: 'center'</code> fell through the
+            scroll-target calculation and returned <code>null</code>, silently leaving the list in
+            place.
+        </p>
+        <p>
+            <strong>Why it's bad:</strong> consumers could not center a search result or restore a persisted
+            raw scroll position through the component's supported programmatic-scroll machinery.
+        </p>
+        <p>
+            <strong>How it's measured:</strong> the first probe scrolls to item {CENTER_INDEX} with center
+            alignment and compares its rendered center with the viewport center. The second probe calls
+            <code>scrollToOffset</code>
+            with {RESTORE_OFFSET_PX}px and reads the viewport's actual <code>scrollTop</code>.
+        </p>
+    </div>
+
+    <div class="stats" data-testid="issue-165-stats">
+        <div
+            class="stat"
+            class:pass={centerPass}
+            class:fail={centerDeltaPx !== null && !centerPass}
+        >
+            <span class="light"
+                >{centerDeltaPx === null ? (running ? '⟳' : '…') : centerPass ? '✓' : '✗'}</span
+            >
+            <span class="label">target is vertically centered</span>
+            <span class="value" data-testid="stat-center">
+                centerDeltaPx={centerDeltaPx ?? '—'}
+            </span>
+            <span class="expected">must be within 2px of the viewport center</span>
+        </div>
+
+        <div class="stat" class:pass={offsetPass} class:fail={scrollTopPx !== null && !offsetPass}>
+            <span class="light"
+                >{scrollTopPx === null ? (running ? '⟳' : '…') : offsetPass ? '✓' : '✗'}</span
+            >
+            <span class="label">raw offset is restored</span>
+            <span class="value" data-testid="stat-offset">scrollTopPx={scrollTopPx ?? '—'}</span>
+            <span class="expected">must be within 2px of {RESTORE_OFFSET_PX}px</span>
+        </div>
+
+        <button class="remeasure" onclick={runProbes} disabled={running}>
+            {running ? 'probing…' : 'Re-run probes'}
+        </button>
+    </div>
+
+    <div class="test-container" style="height: {VIEWPORT_HEIGHT_PX}px;">
+        <SvelteVirtualList
+            defaultEstimatedItemHeight={ITEM_HEIGHT_PX}
+            {items}
+            testId="issue-165-list"
+            bind:this={listRef}
+        >
+            {#snippet renderItem(item)}
+                <div
+                    class="fixed-item"
+                    style="height: {ITEM_HEIGHT_PX}px;"
+                    data-testid="issue-165-item-{item.id}"
+                >
+                    {item.text}
+                </div>
+            {/snippet}
+        </SvelteVirtualList>
+    </div>
+</div>
+
+<style>
+    .page {
+        max-width: 860px;
+        margin: 0 auto;
+        padding: 16px;
+        font-family:
+            system-ui,
+            -apple-system,
+            sans-serif;
+    }
+
+    h1 {
+        font-size: 18px;
+        margin: 0 0 12px;
+    }
+
+    .description {
+        font-size: 13px;
+        line-height: 1.5;
+        color: #333;
+        background: #fafafa;
+        border: 1px solid #eee;
+        border-radius: 8px;
+        padding: 4px 14px;
+        margin-bottom: 12px;
+    }
+
+    .description code {
+        background: #eef2f7;
+        padding: 1px 4px;
+        border-radius: 3px;
+    }
+
+    .stats {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 12px;
+        font-size: 13px;
+    }
+
+    .stat {
+        display: grid;
+        grid-template-columns: 22px 220px minmax(160px, auto) 1fr;
+        gap: 8px;
+        align-items: baseline;
+        padding: 6px 10px;
+        border-radius: 6px;
+        border: 1px solid #e5e5e5;
+        background: #f6f6f6;
+    }
+
+    .stat.pass {
+        background: #e9f7ee;
+        border-color: #b7e2c4;
+    }
+
+    .stat.fail {
+        background: #fdeaea;
+        border-color: #f2b8b8;
+    }
+
+    .light {
+        font-weight: 700;
+    }
+
+    .stat.pass .light,
+    .stat.pass .value {
+        color: #1a7f37;
+    }
+
+    .stat.fail .light,
+    .stat.fail .value {
+        color: #c62828;
+    }
+
+    .label,
+    .value {
+        font-weight: 600;
+    }
+
+    .value {
+        font-variant-numeric: tabular-nums;
+    }
+
+    .expected {
+        color: #777;
+        font-size: 12px;
+    }
+
+    .remeasure {
+        align-self: flex-start;
+        margin-top: 4px;
+        padding: 6px 14px;
+        border: 1px solid #ccc;
+        border-radius: 6px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 13px;
+    }
+
+    .remeasure:disabled {
+        opacity: 0.6;
+        cursor: wait;
+    }
+
+    /* Warning-red backdrop: any unrendered viewport region stays visibly red. */
+    .test-container {
+        width: 100%;
+        background: #ffc2c2;
+    }
+
+    .fixed-item {
+        box-sizing: border-box;
+        padding: 8px 12px;
+        border-bottom: 1px solid #eee;
+        background: #fff;
+        font-size: 14px;
+    }
+</style>

--- a/src/routes/tests/issues/issue-165/+page.svelte
+++ b/src/routes/tests/issues/issue-165/+page.svelte
@@ -12,6 +12,9 @@
     const VIEWPORT_HEIGHT_PX = 400
     const CENTER_INDEX = 500
     const RESTORE_OFFSET_PX = 12_345
+    const PROBE_DELAY_MS = 500
+    const BLANK_BUDGET_MS = 500
+    const BLANK_SAMPLE_TIMEOUT_MS = 3_000
 
     const items: Item[] = Array.from({ length: ITEM_COUNT }, (_, i) => ({
         id: i,
@@ -21,17 +24,71 @@
     let listRef: SvelteVirtualList<Item>
     let centerDeltaPx = $state<number | null>(null)
     let scrollTopPx = $state<number | null>(null)
+    let blankMs = $state<number | null>(null)
     let running = $state(false)
 
     const centerPass = $derived(centerDeltaPx !== null && centerDeltaPx <= 2)
     const offsetPass = $derived(
         scrollTopPx !== null && Math.abs(scrollTopPx - RESTORE_OFFSET_PX) <= 2
     )
+    const blankPass = $derived(blankMs !== null && blankMs <= BLANK_BUDGET_MS)
 
     const getViewport = (): HTMLElement | null =>
         document.querySelector('[data-testid="issue-165-list-viewport"]')
 
     const nextFrame = () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+
+    /**
+     * True when rendered items span the viewport's full visible height —
+     * i.e. none of the warning-red backdrop is showing through.
+     */
+    const viewportCovered = (viewport: HTMLElement): boolean => {
+        const viewportRect = viewport.getBoundingClientRect()
+        const rects = [...viewport.querySelectorAll('[data-testid^="issue-165-item-"]')]
+            .map((el) => el.getBoundingClientRect())
+            .filter((r) => r.bottom > viewportRect.top && r.top < viewportRect.bottom)
+            .sort((a, b) => a.top - b.top)
+        // Walk downward; any >1px gap between consecutive items (or at either
+        // edge) means the red backdrop is showing through.
+        let coveredToPx = viewportRect.top
+        for (const rect of rects) {
+            if (rect.top > coveredToPx + 1) return false
+            coveredToPx = Math.max(coveredToPx, rect.bottom)
+        }
+        return coveredToPx >= viewportRect.bottom - 1
+    }
+
+    /**
+     * Runs a programmatic jump and returns how long the viewport showed any
+     * unrendered (red-backdrop) region, sampled once per animation frame.
+     */
+    const jumpBlankMs = async (
+        viewport: HTMLElement,
+        jump: () => Promise<void>
+    ): Promise<number> => {
+        const startedAt = performance.now()
+        let accumulatedMs = 0
+        let lastSampleAt = startedAt
+        let settled = false
+        const sampler = new Promise<void>((resolve) => {
+            const tick = () => {
+                const now = performance.now()
+                const covered = viewportCovered(viewport)
+                if (!covered) accumulatedMs += now - lastSampleAt
+                lastSampleAt = now
+                if ((settled && covered) || now - startedAt > BLANK_SAMPLE_TIMEOUT_MS) {
+                    resolve()
+                    return
+                }
+                requestAnimationFrame(tick)
+            }
+            requestAnimationFrame(tick)
+        })
+        await jump()
+        settled = true
+        await sampler
+        return Math.round(accumulatedMs)
+    }
 
     const runProbes = async () => {
         const viewport = getViewport()
@@ -39,8 +96,11 @@
         running = true
         centerDeltaPx = null
         scrollTopPx = null
+        blankMs = null
 
-        await listRef.scroll({ index: CENTER_INDEX, align: 'center', smoothScroll: false })
+        const centerBlankMs = await jumpBlankMs(viewport, () =>
+            listRef.scroll({ index: CENTER_INDEX, align: 'center', smoothScroll: false })
+        )
         await nextFrame()
 
         const target = viewport.querySelector(`[data-testid="issue-165-item-${CENTER_INDEX}"]`)
@@ -55,14 +115,17 @@
             centerDeltaPx = 999_999
         }
 
-        await listRef.scrollToOffset({ offset: RESTORE_OFFSET_PX, smoothScroll: false })
+        const offsetBlankMs = await jumpBlankMs(viewport, () =>
+            listRef.scrollToOffset({ offset: RESTORE_OFFSET_PX, smoothScroll: false })
+        )
         await nextFrame()
         scrollTopPx = Math.round(viewport.scrollTop)
+        blankMs = Math.max(centerBlankMs, offsetBlankMs)
         running = false
     }
 
     onMount(() => {
-        const timer = setTimeout(runProbes, 500)
+        const timer = setTimeout(runProbes, PROBE_DELAY_MS)
         return () => clearTimeout(timer)
     })
 </script>
@@ -86,6 +149,12 @@
             alignment and compares its rendered center with the viewport center. The second probe calls
             <code>scrollToOffset</code>
             with {RESTORE_OFFSET_PX}px and reads the viewport's actual <code>scrollTop</code>.
+        </p>
+        <p>
+            <strong>Timing:</strong> the probes run automatically {PROBE_DELAY_MS}ms after load (and
+            on demand via the button). While each jump lands, any not-yet-rendered region shows the
+            warning-red backdrop — brief red flashes during the probes are expected, and the third
+            stat records how long the backdrop was visible.
         </p>
     </div>
 
@@ -112,6 +181,17 @@
             <span class="label">raw offset is restored</span>
             <span class="value" data-testid="stat-offset">scrollTopPx={scrollTopPx ?? '—'}</span>
             <span class="expected">must be within 2px of {RESTORE_OFFSET_PX}px</span>
+        </div>
+
+        <div class="stat" class:pass={blankPass} class:fail={blankMs !== null && !blankPass}>
+            <span class="light"
+                >{blankMs === null ? (running ? '⟳' : '…') : blankPass ? '✓' : '✗'}</span
+            >
+            <span class="label">viewport repaints after jumps</span>
+            <span class="value" data-testid="stat-blank">blankMs={blankMs ?? '—'}</span>
+            <span class="expected"
+                >red backdrop visible ≤ {BLANK_BUDGET_MS}ms (worst of both jumps)</span
+            >
         </div>
 
         <button class="remeasure" onclick={runProbes} disabled={running}>

--- a/tests/issues/issue-165.spec.ts
+++ b/tests/issues/issue-165.spec.ts
@@ -1,0 +1,31 @@
+import { expect, test } from '@playwright/test'
+import { readStats, stat } from '../../src/lib/test/utils/statsLine.js'
+
+/**
+ * Issue #165 — center-aligned programmatic scrolling
+ *
+ * Before the fix, align: 'center' fell through the scroll-target calculation
+ * and returned null, silently leaving the list in place. The fixture scrolls
+ * to item 500, reports the absolute delta between its center and the viewport
+ * center, then restores a raw 12345px position through scrollToOffset.
+ */
+test.describe('Issue 165 - center-aligned programmatic scrolling', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/tests/issues/issue-165', { waitUntil: 'domcontentloaded' })
+        // Require digits so the initial em-dash placeholders cannot satisfy the waits.
+        await expect(page.locator(stat('center'))).toContainText(/centerDeltaPx=\d/, {
+            timeout: 15000
+        })
+        await expect(page.locator(stat('offset'))).toContainText(/scrollTopPx=\d/, {
+            timeout: 15000
+        })
+    })
+
+    test('centers an item and restores a raw pixel offset', async ({ page }) => {
+        const center = await readStats(page, 'center')
+        expect(center.centerDeltaPx).toBeLessThanOrEqual(2)
+
+        const offset = await readStats(page, 'offset')
+        expect(Math.abs(offset.scrollTopPx - 12345)).toBeLessThanOrEqual(2)
+    })
+})

--- a/tests/issues/issue-165.spec.ts
+++ b/tests/issues/issue-165.spec.ts
@@ -7,7 +7,10 @@ import { readStats, stat } from '../../src/lib/test/utils/statsLine.js'
  * Before the fix, align: 'center' fell through the scroll-target calculation
  * and returned null, silently leaving the list in place. The fixture scrolls
  * to item 500, reports the absolute delta between its center and the viewport
- * center, then restores a raw 12345px position through scrollToOffset.
+ * center, then restores a raw 12345px position through scrollToOffset. It also
+ * records how long the warning-red backdrop (unrendered viewport area) stayed
+ * visible across both jumps, so a regression that leaves the viewport blank
+ * after a programmatic jump fails here instead of being eyeballed.
  */
 test.describe('Issue 165 - center-aligned programmatic scrolling', () => {
     test.beforeEach(async ({ page }) => {
@@ -19,6 +22,9 @@ test.describe('Issue 165 - center-aligned programmatic scrolling', () => {
         await expect(page.locator(stat('offset'))).toContainText(/scrollTopPx=\d/, {
             timeout: 15000
         })
+        await expect(page.locator(stat('blank'))).toContainText(/blankMs=\d/, {
+            timeout: 15000
+        })
     })
 
     test('centers an item and restores a raw pixel offset', async ({ page }) => {
@@ -27,5 +33,10 @@ test.describe('Issue 165 - center-aligned programmatic scrolling', () => {
 
         const offset = await readStats(page, 'offset')
         expect(Math.abs(offset.scrollTopPx - 12345)).toBeLessThanOrEqual(2)
+    })
+
+    test('repaints the viewport promptly after programmatic jumps', async ({ page }) => {
+        const blank = await readStats(page, 'blank')
+        expect(blank.blankMs).toBeLessThanOrEqual(500)
     })
 })

--- a/tests/topToBottom/scroll.spec.ts
+++ b/tests/topToBottom/scroll.spec.ts
@@ -6,6 +6,14 @@ test.describe('topToBottom scroll', () => {
     })
 
     async function setAlign(page: Page, value: string) {
+        if (value === 'center') {
+            await page.locator('select').evaluate((select) => {
+                const option = document.createElement('option')
+                option.value = 'center'
+                option.textContent = 'Center'
+                select.append(option)
+            })
+        }
         await page.locator('select').selectOption(value)
     }
 
@@ -97,5 +105,46 @@ test.describe('topToBottom scroll', () => {
         const item2 = page.locator('[data-testid="list-item-501"]')
         await page.waitForFunction(() => !!document.querySelector('[data-testid="list-item-501"]'))
         await expect(item2).toBeVisible()
+    })
+
+    test('should vertically center a mid-list item with align=center', async ({ page }) => {
+        await setAlign(page, 'center')
+        await page.getByLabel('Smooth Scroll').uncheck()
+        await page.locator('input[type=range]').fill('1234')
+        await page.locator('button').click()
+        await page.waitForFunction(() => !!document.querySelector('[data-testid="list-item-1234"]'))
+
+        const centers = await page.evaluate(() => {
+            const viewport = document.querySelector('[data-testid="basic-list-viewport"]')
+            const item = document.querySelector('[data-testid="list-item-1234"]')
+            if (!viewport || !item) throw new Error('Expected viewport and target item')
+            const viewportRect = viewport.getBoundingClientRect()
+            const itemRect = item.getBoundingClientRect()
+            return {
+                viewport: (viewportRect.top + viewportRect.bottom) / 2,
+                item: (itemRect.top + itemRect.bottom) / 2
+            }
+        })
+
+        expect(Math.abs(centers.item - centers.viewport)).toBeLessThanOrEqual(2)
+    })
+
+    test('should clamp align=center for the last item to the maximum scroll position', async ({
+        page
+    }) => {
+        await setAlign(page, 'center')
+        await page.getByLabel('Smooth Scroll').uncheck()
+        await page.locator('input[type=range]').fill('9999')
+        await page.locator('button').click()
+        await page.waitForFunction(() => !!document.querySelector('[data-testid="list-item-9999"]'))
+
+        const position = await page
+            .locator('[data-testid="basic-list-viewport"]')
+            .evaluate((viewport) => ({
+                scrollTop: viewport.scrollTop,
+                maxScrollTop: viewport.scrollHeight - viewport.clientHeight
+            }))
+
+        expect(Math.abs(position.scrollTop - position.maxScrollTop)).toBeLessThanOrEqual(2)
     })
 })


### PR DESCRIPTION
## Summary

Adds `align: 'center'` to programmatic scrolling (requested in #165) and a `scrollToOffset({ offset, smoothScroll })` method for raw-pixel scroll restoration (the use case behind #66). Center targets are clamped to the scrollable range so end-of-list requests land exactly at max scroll instead of stranding `waitForScrollEnd` on an unreachable position; `scrollToOffset` reuses the same abort-safe scroll-execution machinery as `scroll()` via a pure extraction that the existing scroll/keyboard-abort suites verify unchanged.

Red-first: the center test failed against current code (`expected null to be 1820` — the old union fell through to a silent no-scroll) before the implementation. Executed from plan `.agents/.plans/perf-parity/003` by a Codex (GPT-5.6) executor under independent guard review — all gates reproduced on the host: 324/324 unit, 375 e2e passed across 5 engines, trunk clean.

## Changes

- ✨ `SvelteVirtualListScrollAlign` gains `'center'`; centering math in `calculateTopToBottomScrollTarget` with a new optional `maxScrollTop` param (composes with the existing `blockSums`)
- ✨ `scrollToOffset({ offset, smoothScroll })` — clamped, abort-safe, promise-returning raw-offset scrolling
- 🔧 Extract `executeScrollToTarget` (the shared post-target scroll machinery: depth guard, scrollTo, rAF state sync, `waitForScrollEnd` chain) — pure refactor consumed by both `scroll()` and `scrollToOffset`
- 🧪 5 new unit tests for center math (uniform/measured heights, taller-than-viewport, clamp at 0 and at max)
- 🧪 Self-judging fixture at `/tests/issues/issue-165` (red/green stat rows: `centerDeltaPx ≤ 2`, offset restore within 2px) + Playwright spec; two deterministic center cases added to `scroll.spec.ts` (smooth-scroll disabled to avoid animation races)
- 📚 README: `'center'` in the align docs and `scrollToOffset` next to `scroll()`

## Commits

- [`032e818`](https://github.com/humanspeak/svelte-virtual-list/commit/032e818cb8bd8c67c930025b2420447ae9aac3ad) feat(virtual-list): support align center in scroll() (#165)
- [`9860eb5`](https://github.com/humanspeak/svelte-virtual-list/commit/9860eb5cb0e5f35e2d2e4c82e557ddf9f297a86d) feat(virtual-list): add scrollToOffset() and issue-165 center fixture (#165, #66)

## Notes for review

- The deprecated `scrollToIndex` wrapper is byte-identical (verified) — only shifted by insertions after it.
- Center for items taller than the viewport anchors past-center then clamps; virtuoso-style top-anchoring for oversized items is a recorded follow-up if requested.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
