### PR TITLE
build(docs): bump docs-kit to 2026.7.6

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -26,7 +26,7 @@
     "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
         "@fontsource-variable/jetbrains-mono": "^5.2.8",
-        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.6.16",
+        "@humanspeak/docs-kit": "github:humanspeak/docs-kit#2026.7.6",
         "@humanspeak/svelte-markdown": "^1.6.0",
         "@humanspeak/svelte-motion": "^0.6.6",
         "@humanspeak/svelte-virtual-list": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "peerDependencies": {
         "svelte": "^5.0.0"
     },
-    "packageManager": "pnpm@11.5.0",
+    "packageManager": "pnpm@11.9.0",
     "volta": {
         "node": "24.15.0"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^5.2.8
         version: 5.2.8
       '@humanspeak/docs-kit':
-        specifier: github:humanspeak/docs-kit#2026.6.16
-        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e(@humanspeak/svelte-markdown@1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@humanspeak/svelte-motion@0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/kit@2.64.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(shiki@4.2.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(zod@4.4.3)
+        specifier: github:humanspeak/docs-kit#2026.7.6
+        version: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@humanspeak/svelte-motion@0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/kit@2.64.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(shiki@4.2.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(zod@4.4.3)
       '@humanspeak/svelte-markdown':
         specifier: ^1.6.0
         version: 1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0))
@@ -929,8 +929,8 @@ packages:
     resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e':
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e}
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc':
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc}
     version: 0.0.0
     peerDependencies:
       '@humanspeak/svelte-markdown': '>=1.0.0'
@@ -4909,7 +4909,7 @@ snapshots:
 
   '@humanfs/types@0.15.0': {}
 
-  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/30c325691f170eb5877519a4aac2f32015d02a5e(@humanspeak/svelte-markdown@1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@humanspeak/svelte-motion@0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/kit@2.64.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(shiki@4.2.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(zod@4.4.3)':
+  '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc(@humanspeak/svelte-markdown@1.6.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@humanspeak/svelte-motion@0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@internationalized/date@3.12.2)(@lucide/svelte@1.17.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(@sveltejs/kit@2.64.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3(@typescript-eslint/types@8.61.0))(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(svelte@5.56.3(@typescript-eslint/types@8.61.0))(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.4)))(mode-watcher@1.1.0(svelte@5.56.3(@typescript-eslint/types@8.61.0)))(shiki@4.2.0)(svelte@5.56.3(@typescript-eslint/types@8.61.0))(zod@4.4.3)':
     dependencies:
       '@humanspeak/svelte-motion': 0.6.6(svelte@5.56.3(@typescript-eslint/types@8.61.0))
       '@humanspeak/svelte-satori-fix': 0.0.6(svelte@5.56.3(@typescript-eslint/types@8.61.0))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,11 @@ minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
     - '@humanspeak/*'
 allowBuilds:
-    '@humanspeak/docs-kit': true
+    # pnpm 11.9 matches git-hosted deps by name@resolved-url (pnpm#10522) — a
+    # plain package-name key does NOT match. This key embeds the resolved
+    # commit of docs-kit#<tag>, so it must be refreshed whenever the docs-kit
+    # tag in docs/package.json bumps (pnpm approve-builds will prompt).
+    '@humanspeak/docs-kit@https://codeload.github.com/humanspeak/docs-kit/tar.gz/a474a0725babdda6f267951a578d14289037b0cc': true
     '@sentry/cli': true
     esbuild: true
     sharp: true


### PR DESCRIPTION
Bumps `@humanspeak/docs-kit` to `2026.7.6`, refreshes the `allowBuilds` resolved-commit key in `pnpm-workspace.yaml`, and bumps `packageManager` to `pnpm@11.9.0` (the resolved-URL key format requires it — pnpm 11.9 matches git-hosted deps by `name@resolved-url`). Lockfile re-resolved.

Mirrors the setup already on `svelte-motion`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)